### PR TITLE
Add command-line arguments and config file support

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,15 @@
 {
+    "config": {
+        "output_dir": "output",
+        "resolvers": "1.1.1.1,8.8.8.8,208.67.222.22",
+        "max_threads": 2,
+        "timeout": 1,
+        "verbose": true,
+        "retries": 2,
+        "evidence": true,
+        "service_checks": true,
+        "extreme": false
+    },
     "ssl_tls_ports": [443, 8443, 8080, 8888, 8000],
     "http_ports": [80, 8080, 8000, 8888],
     "domain_categorization": {

--- a/resolver.py
+++ b/resolver.py
@@ -57,7 +57,6 @@ def main(
     :param retries: Number of times to retry failed resolutions. (int)
     :param evidence: Flag to enable evidence collection during domain resolution. (bool)
     :return: None
-
     """
 
     # Initialize environment and create necessary directories and files


### PR DESCRIPTION
Additional command-line arguments were introduced for enhanced configurability. User can now specify a configuration file as an argument. If attributes are not given as command-line arguments, they are fetched from this configuration file. In addition, the help messages are improved to specify that command-line argument settings will override those set in the configuration file.