### PR TITLE
fix: get_gcp_ipv4 was returning gcp_ipv6

### DIFF
--- a/classes/domain_processing_context.py
+++ b/classes/domain_processing_context.py
@@ -197,7 +197,7 @@ class DomainProcessingContext:
         """
         Retrieve the Google Cloud Platform IPV4 address.
         """
-        return self.gcp_ipv6
+        return self.gcp_ipv4
 
     def get_aws_ipv4(self):
         """


### PR DESCRIPTION
## Summary

- Closes #30
- `get_gcp_ipv4()` in `DomainProcessingContext` had a copy-paste error and was returning `self.gcp_ipv6` instead of `self.gcp_ipv4`
- This caused GCP IPv4 range matching to silently use IPv6 ranges, meaning domains resolving to GCP IPv4 addresses would never be flagged

## Test plan

- [ ] Run against a domain known to resolve to a GCP IPv4 address — confirm it appears in `gcp_results_*.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)