### PR TITLE
feat: async redesign — replace threading with asyncio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ results
 output
 Source/*
 dns_resolver.log
+.venv/
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-Sure, here's a markdown-formatted `README.md` for your DNSResolver project. This file includes an overview, installation
-instructions, usage, and a link to a demonstration video.
-
-```markdown
 # DNSResolver
 
 DNSResolver is a Python-based tool designed to perform DNS resolution and check resolved IP addresses against known IP

--- a/README.md
+++ b/README.md
@@ -1,83 +1,95 @@
 # DNSResolver
 
-DNSResolver is a Python-based tool designed to perform DNS resolution and check resolved IP addresses against known IP
-ranges of major Cloud Service Providers (CSP) such as AWS, GCP, and Azure. It includes functionalities for domain
-processing, logging, and evidence collection.
+DNSResolver is a Python-based security tool for bulk DNS resolution and cloud infrastructure analysis. Given a list of domains it:
 
-## Features
+- Resolves DNS records and matches resolved IPs against known IP ranges for **AWS, GCP, and Azure**
+- Detects **dangling CNAME** records pointing to unclaimed cloud resources (potential subdomain takeover)
+- Detects **NS takeover** opportunities where nameservers are unresolvable
+- Collects forensic evidence (dig/nslookup output) for flagged domains
+- Performs optional **service connectivity checks** (HTTP, TLS, TCP port scanning)
 
-- DNS resolution for given domains
-- IP range checking against known CSPs (AWS, GCP, Azure)
-- Logging of results
-- Evidence collection for resolved IPs
+All domain processing runs concurrently using `asyncio`, making it practical for large domain lists.
+
+## Demonstration
+
+![DNSResolver Demo](Media/simplerun.gif)
 
 ## Installation
 
-To get started with DNSResolver, follow these steps:
-
-1. **Clone the repository:**
-
-   ```bash
-   git clone https://github.com/incendiary/DNSResolver.git
-   cd DNSResolver
-   ```
-
-2. **Create and activate a virtual environment:**
-
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate  # On Windows use `venv\Scripts\activate`
-   ```
-
-3. **Install the required dependencies:**
-
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+git clone https://github.com/incendiary/DNSResolver.git
+cd DNSResolver
+python3 -m venv venv
+source venv/bin/activate        # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
 
 ## Usage
 
-DNSResolver can be run with various options to perform DNS resolution and check against CSP IP ranges.
-
-### Basic Usage
-
 ```bash
-python resolver.py -d domains.txt -o output
+python resolver.py <domains_file> [options]
 ```
 
-- `-d`: Path to the file containing the list of domains to be resolved.
-- `-o`: Output directory where results will be saved.
+`domains_file` — path to a plain-text file with one domain per line.
 
-### Advanced Options
+### Options
 
-- `-c`: Configuration file path (default: `config.json`).
-- `-v`: Enable verbose logging.
-- `-e`: Enable extreme logging.
-- `-n`: Custom nameservers for DNS resolution.
-- `-t`: Timeout for DNS queries.
-- `-r`: Number of retries for DNS queries.
-- `--evidence`: Enable evidence collection for resolved IPs.
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--output-dir` | `-o` | Directory to save results (default: `output`) |
+| `--config-file` | | Path to config JSON (default: `config.json`) |
+| `--verbose` | `-v` | Enable verbose logging |
+| `--extreme` | `-e` | Enable extreme logging (includes full IP range dumps, implies `-v`) |
+| `--nameservers` | | Comma-separated custom resolvers, e.g. `8.8.8.8,1.1.1.1` |
+| `--service-checks` | `-sc` | Enable HTTP/TLS/TCP service connectivity checks |
+| `--max-threads` | `-mt` | Max concurrent domain tasks (default: 50) |
+| `--timeout` | `-t` | DNS query timeout in seconds |
+| `--retries` | | Retry attempts for failed domains (default from config) |
+| `--evidence` | | Save dig/nslookup output for flagged domains |
 
 ### Example
 
 ```bash
-python resolver.py -d domains.txt -o output --evidence -v -n 8.8.8.8,1.1.1.1 -t 2 -r 3
+python resolver.py domains.txt -o results --evidence -v --nameservers 8.8.8.8,1.1.1.1 --timeout 5 --retries 2
 ```
 
-## Demonstration
+## Output
 
-For a quick demonstration of DNSResolver in action, watch the video below:
+Each run creates a timestamped subdirectory under the output directory containing:
 
-![DNSResolver Demo](Media/simplerun.gif)
+| File | Contents |
+|------|----------|
+| `resolution_results_*.txt` | Successfully resolved domains and their DNS records |
+| `unresolved_results_*.txt` | Domains that could not be resolved after all retries |
+| `dangling_cname_results_*.txt` | Domains with dangling CNAMEs — category, recommendation, and evidence link |
+| `ns_takeover_results_*.txt` | Domains with potentially unresolvable nameservers |
+| `gcp_results_*.txt` | Domains resolving to GCP IP ranges |
+| `aws_results_*.txt` | Domains resolving to AWS IP ranges |
+| `azure_results_*.txt` | Domains resolving to Azure IP ranges |
+| `environment_results_*.json` | Run metadata (command, external IP, Docker status) |
+| `evidence/dns/` | dig or nslookup output per flagged domain (when `--evidence` is set) |
+
+## Architecture
+
+```
+resolver.py          — asyncio entry point, retry loop, concurrency cap
+├── EnvironmentManager   — argument parsing, config, logging, output setup
+├── DNSHandler           — async DNS resolution (aiodns primary, dnspython fallback)
+│   └── EvidenceCollector — async subprocess evidence capture (dig/nslookup)
+├── DomainProcessingContext — per-domain state (domain name, resolver, CSP IPs)
+├── CSPIPAddresses       — value object holding fetched AWS/GCP/Azure IP ranges
+└── domain_processor.py  — orchestrates DNS → CSP checks → service checks per domain
+```
+
+Domain processing uses `asyncio.gather` with a `Semaphore` cap (`--max-threads`) to run many domains concurrently without exhausting file descriptors or triggering DNS rate limits. Failed domains are collected after each pass and retried up to `--retries` times.
+
+## Configuration
+
+`config.json` sets defaults for timeout, retries, output directory, and domain categorisation patterns used for classifying dangling CNAME targets (e.g. AWS S3, GitHub Pages, Heroku). CLI flags always override config file values.
 
 ## Contributing
 
-We welcome contributions to DNSResolver. If you'd like to contribute, please follow these steps:
-
-1. Fork the repository.
-2. Create a new branch (`git checkout -b feature-branch`).
-3. Make your changes.
-4. Commit your changes (`git commit -am 'Add new feature'`).
-5. Push to the branch (`git push origin feature-branch`).
-6. Create a new Pull Request.
-
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-change`)
+3. Commit your changes
+4. Push and open a Pull Request

--- a/classes/csp_ip_addresses.py
+++ b/classes/csp_ip_addresses.py
@@ -1,0 +1,85 @@
+class CSPIPAddresses:
+    """
+    A class to store IP ranges for various Cloud Service Providers (CSPs).
+
+    Attributes:
+        gcp_ipv4 (list): Google Cloud Platform IPv4 ranges.
+        gcp_ipv6 (list): Google Cloud Platform IPv6 ranges.
+        aws_ipv4 (list): AWS IPv4 ranges.
+        aws_ipv6 (list): AWS IPv6 ranges.
+        azure_ipv4 (list): Azure IPv4 ranges.
+        azure_ipv6 (list): Azure IPv6 ranges.
+    """
+
+    def __init__(self, gcp_ipv4, gcp_ipv6, aws_ipv4, aws_ipv6, azure_ipv4, azure_ipv6):
+        """
+        Initialize CSPIPAddresses with IP ranges for GCP, AWS, and Azure.
+
+        Args:
+            gcp_ipv4 (list): Google Cloud Platform IPv4 ranges.
+            gcp_ipv6 (list): Google Cloud Platform IPv6 ranges.
+            aws_ipv4 (list): AWS IPv4 ranges.
+            aws_ipv6 (list): AWS IPv6 ranges.
+            azure_ipv4 (list): Azure IPv4 ranges.
+            azure_ipv6 (list): Azure IPv6 ranges.
+        """
+        self.gcp_ipv4 = gcp_ipv4
+        self.gcp_ipv6 = gcp_ipv6
+        self.aws_ipv4 = aws_ipv4
+        self.aws_ipv6 = aws_ipv6
+        self.azure_ipv4 = azure_ipv4
+        self.azure_ipv6 = azure_ipv6
+
+    def get_gcp_ipv4(self):
+        """
+        Get Google Cloud Platform IPv4 ranges.
+
+        Returns:
+            list: Google Cloud Platform IPv4 ranges.
+        """
+        return self.gcp_ipv4
+
+    def get_gcp_ipv6(self):
+        """
+        Get Google Cloud Platform IPv6 ranges.
+
+        Returns:
+            list: Google Cloud Platform IPv6 ranges.
+        """
+        return self.gcp_ipv6
+
+    def get_aws_ipv4(self):
+        """
+        Get AWS IPv4 ranges.
+
+        Returns:
+            list: AWS IPv4 ranges.
+        """
+        return self.aws_ipv4
+
+    def get_aws_ipv6(self):
+        """
+        Get AWS IPv6 ranges.
+
+        Returns:
+            list: AWS IPv6 ranges.
+        """
+        return self.aws_ipv6
+
+    def get_azure_ipv4(self):
+        """
+        Get Azure IPv4 ranges.
+
+        Returns:
+            list: Azure IPv4 ranges.
+        """
+        return self.azure_ipv4
+
+    def get_azure_ipv6(self):
+        """
+        Get Azure IPv6 ranges.
+
+        Returns:
+            list: Azure IPv6 ranges.
+        """
+        return self.azure_ipv6

--- a/classes/dns_handler.py
+++ b/classes/dns_handler.py
@@ -1,0 +1,384 @@
+import asyncio
+import json
+import os
+import platform
+import re
+import subprocess
+
+import aiodns
+
+# Define constants for DNS error codes
+NXDOMAIN = 3
+SERVFAIL = 2
+NO_DATA = 1
+TIMEOUT = 4
+REFUSED = 5
+
+
+class DNSHandler:
+    def __init__(self, env_manager):
+        self.env_manager = env_manager
+        self.resolver = aiodns.DNSResolver()
+
+    @staticmethod
+    def is_dns_error_present(error, error_types):
+        """
+        Checks if a DNS error is of certain types.
+
+        :param error: The occurred DNS error.
+        :param error_types: A list of error types to check against.
+        :return: Boolean value indicating if the error is of certain types.
+        """
+        return error.args[0] in error_types
+
+    async def collect_evidence(self, domain, reason, output_files):
+        """
+        Collects DNS evidence using either nslookup or dig, depending on system availability.
+
+        :param domain: The domain name to perform the DNS lookup for.
+        :param reason: The reason for performing the DNS lookup.
+        :param output_files: The output files configuration from the environment manager.
+        :return: None
+        """
+        evidence_enabled = self.env_manager.get_evidence()
+        if evidence_enabled:
+            tasks = [
+                self.perform_dns_evidence(
+                    domain,
+                    nameserver,
+                    reason,
+                    output_files["evidence"]["dns"],
+                )
+                for nameserver in self.env_manager.get_resolvers()
+            ]
+
+            await asyncio.gather(*tasks)
+
+    async def check_ns_takeover(self, domain_context, domain):
+        """
+        Asynchronously check if the NS records for the given domain are pointing to nameservers
+        that are not resolvable (potential nameserver takeover).
+
+        :param domain_context: The domain context instance.
+        :param domain: The domain to check.
+        :return: True if potential nameserver takeover is detected, False otherwise.
+        """
+        original_domain = domain_context.get_domain()
+        output_files = self.env_manager.get_output_files()
+
+        try:
+            ns_records = await self.resolver.query(domain, "NS")
+            for ns in ns_records:
+                ns_domain = str(ns.host).strip(".")
+                try:
+                    await self.resolver.query(ns_domain, "A")
+                except aiodns.error.DNSError as e:
+                    if self.is_dns_error_present(e, [NXDOMAIN, SERVFAIL]):
+                        await self.env_manager.write_to_file(
+                            output_files["standard"]["ns_takeover"],
+                            f"{original_domain}|{domain}",
+                        )
+                        self.env_manager.log_info(
+                            f"NS takeover possible for domain {domain}"
+                        )
+
+                        await self.collect_evidence(domain, "ns_takeover", output_files)
+
+                        return True
+        except aiodns.error.DNSError as e:
+            if self.is_dns_error_present(e, [NXDOMAIN, SERVFAIL]):
+                pass
+        return False
+
+    @staticmethod
+    async def load_domain_categorisation_patterns(config_file="config.json"):
+        """
+        Load domain categorization patterns from the given config file.
+
+        :param config_file: The path to the config file. Defaults to "config.json".
+        :type config_file: str
+        :return: A dictionary of domain categorization patterns.
+        :rtype: dict
+        """
+        with open(config_file, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        return config.get("domain_categorization", {})
+
+    @staticmethod
+    def categorise_domain(domain, patterns):
+        """
+        Categorizes a domain based on a set of patterns.
+
+        :param domain: The domain to categorize.
+        :param patterns: A dictionary containing patterns to match against the domain.
+        :return: A tuple containing the category, recommendation, and evidence link.
+        """
+        for category, pattern in patterns.items():
+            if re.search(pattern["regex"], domain):
+                return category, pattern["recommendation"], pattern["evidence"]
+        return "unknown", "Unclassified", "N/A"
+
+    @staticmethod
+    async def is_dangling_record_async(resolver, domain, record_type):
+        """
+        Asynchronously checks if a specified DNS record for a given domain is a dangling record or not.
+
+        :param resolver: The aiodns resolver instance.
+        :param domain: The domain to check.
+        :param record_type: The type of DNS record to check (e.g., A, AAAA, MX, NS).
+        :return: True if the record is dangling, False otherwise.
+        """
+        try:
+            await resolver.query(domain, record_type)
+            return False
+        except aiodns.error.DNSError as e:
+            return DNSHandler.is_dns_error_present(e, [NXDOMAIN, SERVFAIL])
+
+    @staticmethod
+    def check_tools_availability():
+        """
+        Check the availability of nslookup and dig tools in the system path.
+
+        :return: Tuple indicating the availability of nslookup and dig (nslookup_available, dig_available).
+        """
+        if platform.system() == "Windows":
+            nslookup_available = (
+                subprocess.run(
+                    ["where", "nslookup"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+            dig_available = (
+                subprocess.run(
+                    ["where", "dig"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+        else:
+            nslookup_available = (
+                subprocess.run(
+                    ["which", "nslookup"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+            dig_available = (
+                subprocess.run(
+                    ["which", "dig"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+
+        return nslookup_available, dig_available
+
+    async def handle_domain_resolution_errors(
+        self, domain_context, current_domain, error
+    ):
+        if self.is_dns_error_present(error, [NXDOMAIN]):
+            self.env_manager.log_info(
+                f"{current_domain} not found, checking for dangling CNAME."
+            )
+            if await self.handle_takeover_checks(domain_context, current_domain):
+                return True, []
+        elif self.is_dns_error_present(error, [SERVFAIL]):
+            await self.log_and_write_dns_error(
+                current_domain, error, "Could not contact DNS servers"
+            )
+        else:
+            await self.log_and_write_dns_error(current_domain, error)
+        return False, []
+
+    async def handle_takeover_checks(self, domain_context, current_domain):
+        is_dangling = await self.check_dangling_cname_async(
+            domain_context, current_domain
+        )
+        is_nstakeover = await self.check_ns_takeover(domain_context, current_domain)
+        if is_dangling or is_nstakeover:
+            domain_context.add_dangling_domain_to_domains(current_domain)
+        return is_dangling or is_nstakeover
+
+    async def log_and_write_dns_error(self, domain, error, additional_message=""):
+        message = f"DNS resolution error for {domain}: {error}"
+        if additional_message:
+            message += f"|{additional_message}"
+        self.env_manager.log_error(message)
+        await self.env_manager.write_to_file(
+            self.env_manager.get_output_files()["standard"]["unresolved"],
+            message,
+        )
+
+    async def resolve_domain_async(self, domain_context):
+        """
+        Asynchronously resolves a domain and returns a success status and the final IP addresses.
+
+        :param domain_context: The domain context instance.
+        :return: Tuple containing a boolean success status and a list of resolved IP addresses.
+        """
+        resolved_records = []
+        current_domain = domain_context.get_domain()
+        random_nameserver = self.env_manager.get_random_nameserver()
+        if random_nameserver:
+            self.resolver.nameservers = [random_nameserver]
+            self.env_manager.log_info(
+                f"Using nameserver {random_nameserver} for resolving {current_domain}"
+            )
+        try:
+            answers = await self.resolver.query(current_domain, "A")
+            final_ips = [answer.host for answer in answers]
+            resolved_records.append(("A", final_ips))
+            await self.handle_takeover_checks(domain_context, current_domain)
+            return True, final_ips
+        except aiodns.error.DNSError as e:
+            return await self.handle_domain_resolution_errors(
+                domain_context, current_domain, e
+            )
+
+    async def save_and_log_dns_result(
+        self, result, domain, nameserver, reason, evidence_dir, command_name
+    ):
+        """
+        Save and log the result of a DNS query command.
+
+        :param result: The subprocess result object.
+        :param domain: The domain name queried.
+        :param nameserver: The nameserver used for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :param command_name: The name of the DNS query command (e.g., nslookup, dig).
+        :return: None
+        """
+        stdout, stderr = await result.communicate()
+        content = stdout.decode() + "\n" + stderr.decode()
+        filename = os.path.join(evidence_dir, f"{domain}_{reason}_{nameserver}.txt")
+        await self.env_manager.write_to_file(filename, content)
+        self.env_manager.log_info(
+            f"{command_name} result saved for domain {domain} using nameserver {nameserver}"
+        )
+
+    async def perform_nslookup(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using the nslookup command and save the output to a file.
+
+        :param domain: The domain name to query.
+        :param nameserver: The nameserver to use for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :return: None
+        """
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "nslookup",
+                domain,
+                nameserver,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await self.save_and_log_dns_result(
+                result, domain, nameserver, reason, evidence_dir, "nslookup"
+            )
+        except Exception as e:
+            self.env_manager.log_error(f"Command failed with error: {e}")
+            raise e from None
+
+    async def perform_dig(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using the dig command and save the output to a file.
+
+        :param domain: The domain name to query.
+        :param nameserver: The nameserver to use for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :return: None
+        """
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "dig",
+                f"@{nameserver}",
+                domain,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await self.save_and_log_dns_result(
+                result, domain, nameserver, reason, evidence_dir, "dig"
+            )
+        except Exception as e:
+            self.env_manager.log_error(f"Command failed with error: {e}")
+            raise e from None
+
+    async def perform_dns_evidence(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using either nslookup or dig, depending on the system.
+
+        :param domain: The domain name to perform the DNS lookup for.
+        :param nameserver: The nameserver to use for the DNS lookup.
+        :param reason: The reason for performing the DNS lookup.
+        :param evidence_dir: The directory where the output file will be saved.
+        :return: None
+        """
+        nslookup_available, dig_available = self.check_tools_availability()
+
+        if platform.system() == "Windows":
+            if nslookup_available:
+                await self.perform_nslookup(domain, nameserver, reason, evidence_dir)
+            else:
+                self.env_manager.log_error(
+                    f"nslookup not available on Windows system for domain {domain}"
+                )
+        else:
+            if dig_available:
+                await self.perform_dig(domain, nameserver, reason, evidence_dir)
+            elif nslookup_available:
+                await self.perform_nslookup(domain, nameserver, reason, evidence_dir)
+            else:
+                self.env_manager.log_error(
+                    f"Neither dig nor nslookup available on non-Windows system for domain {domain}"
+                )
+
+    async def check_dangling_cname_async(self, domain_context, current_domain):
+        """
+        Asynchronously checks if a domain is a dangling CNAME, returning a boolean result.
+
+        :param domain_context: The domain context instance.
+        :param current_domain: The current domain to check.
+        :return: True if the domain is a dangling CNAME, False otherwise.
+        """
+        original_domain = domain_context.get_domain()
+        output_files = self.env_manager.get_output_files()
+
+        random_nameserver = self.env_manager.get_random_nameserver()
+        if random_nameserver:
+            self.resolver.nameservers = [random_nameserver]
+            self.env_manager.log_info(
+                f"Using nameserver {random_nameserver} for resolving {current_domain}"
+            )
+
+        for record_type in ["A", "AAAA", "MX"]:
+            if not await self.is_dangling_record_async(
+                self.resolver, current_domain, record_type
+            ):
+                return False
+
+        if not await self.is_dangling_record_async(self.resolver, current_domain, "NS"):
+            await self.env_manager.write_to_file(
+                output_files["standard"]["ns_takeover"],
+                f"{original_domain}|{current_domain}",
+            )
+            self.env_manager.log_info(
+                f"NS takeover possible for domain {current_domain}"
+            )
+            return False
+
+        patterns = self.env_manager.get_patterns()
+        category, recommendation, evidence_link = self.categorise_domain(
+            current_domain, patterns
+        )
+        await self.env_manager.write_to_file(
+            output_files["standard"]["dangling"],
+            f"{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}",
+        )
+        self.env_manager.log_info(
+            f"Domain {current_domain} is a dangling CNAME with category: {category}"
+        )
+
+        await self.collect_evidence(current_domain, "dangling", output_files)
+
+        return True

--- a/classes/dns_handler.py
+++ b/classes/dns_handler.py
@@ -183,9 +183,12 @@ class DNSHandler:
                 f"DNS resolution error for {current_domain}: {error} | final_retry={final_retry}"
             )
 
-        # Use dnspython_resolver for better error handling
+        # Second-opinion check using dnspython — run in executor to avoid blocking the event loop
+        loop = asyncio.get_event_loop()
         try:
-            self.dnspython_resolver.resolve(current_domain, "A")
+            await loop.run_in_executor(
+                None, self.dnspython_resolver.resolve, current_domain, "A"
+            )
             self.env_manager.log_info(
                 f"Domain {current_domain} resolved successfully with dnspython_resolver."
             )
@@ -318,27 +321,23 @@ class DNSHandler:
         # Check for dangling A, AAAA, MX records
         for record_type in ["A", "AAAA", "MX"]:
             try:
-                self.dnspython_resolver.resolve(current_domain, record_type)
+                await self.aiodns_resolver.query(current_domain, record_type)
                 self.env_manager.log_info(
                     f"Domain {current_domain} has a valid {record_type} record."
                 )
                 return False
-            except (
-                dns.resolver.NoAnswer,
-                dns.resolver.NXDOMAIN,
-                dns.exception.Timeout,
-            ) as e:
+            except aiodns.error.DNSError as e:
                 self.env_manager.log_info(
                     f"Error querying {record_type} for {current_domain}: {e}"
                 )
-                if isinstance(e, dns.resolver.NoAnswer):
+                if self.is_dns_error_present(e, [NO_DATA]):
                     continue
-                if isinstance(e, dns.exception.Timeout):
+                if self.is_dns_error_present(e, [TIMEOUT]):
                     return False
 
-        # Check NS records for original domain
+        # Check NS records for current_domain to detect potential NS takeover
         try:
-            self.dnspython_resolver.resolve(original_domain, "NS")
+            await self.aiodns_resolver.query(current_domain, "NS")
             await self.env_manager.write_to_file(
                 output_files["standard"]["ns_takeover"],
                 f"{original_domain}|{current_domain}",
@@ -347,14 +346,8 @@ class DNSHandler:
                 f"NS takeover possible for domain {current_domain}"
             )
             return False
-        except (
-            dns.resolver.NoAnswer,
-            dns.resolver.NXDOMAIN,
-            dns.exception.Timeout,
-        ) as e:
-            self.env_manager.log_info(f"Error querying NS for {original_domain}: {e}")
-            if isinstance(e, dns.resolver.NoAnswer):
-                pass
+        except aiodns.error.DNSError as e:
+            self.env_manager.log_info(f"Error querying NS for {current_domain}: {e}")
 
         patterns = self.env_manager.get_patterns()
         category, recommendation, evidence_link = self.categorise_domain(

--- a/classes/domain_processing_context.py
+++ b/classes/domain_processing_context.py
@@ -14,27 +14,12 @@ class DomainProcessingContext:
     Class representing the context for domain processing.
 
     Attributes:
+        env_manager (EnvironmentManager): The environment manager object.
         resolver (dns.resolver.Resolver): DNS resolver object.
         domain: The root domain to which this context applies.
         current_domain: The current domain being processed.
-        nameservers: List of nameservers for DNS resolution.
-        output_files: List of output files to write the results to.
-        verbose: Flag indicating the status of verbose mode.
-        extreme: Flag indicating the status of extreme mode.
-        gcp_ipv4: Google Cloud Platform IPv4 address.
-        gcp_ipv6: Google Cloud Platform IPv6 address.
-        aws_ipv4: Amazon Web Services IPv4 address.
-        aws_ipv6: Amazon Web Services IPv6 address.
-        azure_ipv4: Microsoft Azure IPv4 address.
-        azure_ipv6: Microsoft Azure IPv6 address.
-        perform_service_checks: Flag indicating the status of service checks.
-        timeout: DNS resolution timeout value.
-        retries: Number of retries for DNS resolution.
-        patterns: List of domain name matching patterns.
         dangling_domains: Set of discovered dangling domains.
         failed_domains: Set of failed domains.
-        evidence_enabled: Flag indicating the status of evidence collection.
-        logger: The logger object.
 
     Methods:
         create_resolver: Create and configure a DNS resolver object.
@@ -44,81 +29,38 @@ class DomainProcessingContext:
         set_domain: Set the root domain to which this context applies.
         get_current_domain: Retrieve the current domain being processed.
         set_current_domain: Set the current domain to be processed.
-        get_nameservers: Get the list of nameservers for DNS resolution.
-        set_nameservers: Set the list of nameservers for DNS resolution.
-        get_output_files: Get the list of output files to write the results to.
-        set_output_files: Set the list of output files to write the results to.
-        get_verbose: Get the status of verbose mode.
-        set_verbose: Set the status of verbose mode.
-        get_extreme: Get the status of extreme mode.
-        set_extreme: Set the status of extreme mode.
-        set_gcp_ip: Set both IPv4 and IPv6 addresses of Google Cloud Platform.
-        get_gcp_ipv6: Retrieve the Google Cloud Platform IPv6 address.
-        get_aws_ipv4: Get the Amazon Web Services IPv4 address.
-        set_aws_ip: Set both IPv4 and IPv6 addresses of Amazon Web Services.
-        get_aws_ipv6: Get the Amazon Web Services IPv6 address.
-        get_azure_ipv4: Get the Microsoft Azure IPv4 address.
-        set_azure_ip: Set both IPv4 and IPv6 addresses of Microsoft Azure.
-        get_azure_ipv6: Get the Microsoft Azure IPv6 address.
-        set_azure_ipv6: Sets the Azure IPv6.
-        get_perform_service_checks: Get the status of service checks.
-        set_perform_service_checks: Sets the status of service checks.
-        get_timeout: Get the DNS resolution timeout value.
-        set_timeout: Set the DNS resolution timeout value.
-        get_retries: Get the number of retries for DNS resolution.
-        set_retries: Set the number of retries for DNS resolution.
-        get_patterns: Get the list of domain name matching patterns.
-        set_patterns: Set the domain name matching patterns.
-        get_dangling_domains: Get the set of discovered dangling domains.
-        set_dangling_domains: Set the set of discovered dangling domains.
-        add_dangling_domain_to_domains: Add a dangling domain to the set of
-            dangling domains.
-        get_failed_domains: Get the set of failed domains.
-        set_failed_domains: Set the set of failed domains.
-        get_evidence_enabled: Get the status of evidence collection.
-        set_evidence_enabled: Set the status of evidence collection.
-        get_logger: Get the logger object.
-        set_logger: Set the logger object.
     """
 
-    def __init__(self, env_manager):
+    def __init__(self, env_manager, csp_ip_addresses):
         """Initialize DomainProcessingContext instance."""
-        self.nameservers = None
-        self.output_files = None
-        self.verbose = False
-        self.extreme = False
-        self.gcp_ipv4 = None
-        self.gcp_ipv6 = None
-        self.aws_ipv4 = None
-        self.aws_ipv6 = None
-        self.azure_ipv4 = None
-        self.azure_ipv6 = None
-        self.perform_service_checks = False
-        self.timeout = None
-        self.retries = None
-        self.patterns = None
-        self.dangling_domains = None
-        self.failed_domains = None
-        self.evidence_enabled = False
-        self.logger = env_manager.get_logger()
+        self.env_manager = env_manager
         self.resolver = None
+        self.csp_ip_addresses = csp_ip_addresses
         self.domain = None
         self.current_domain = None
+        self.dangling_domains = set()
+        self.failed_domains = set()
 
     def create_resolver(self):
         """Create and configure a DNS resolver object."""
         self.resolver = dns.resolver.Resolver()
-        self.resolver.lifetime = self.timeout
-        self.resolver.timeout = self.timeout
-        if self.nameservers:
-            self.resolver.nameservers = self.nameservers
+        self.resolver.lifetime = self.env_manager.get_timeout()
+        self.resolver.timeout = self.env_manager.get_timeout()
+        nameservers = self.env_manager.get_resolvers()
+        if nameservers:
+            self.resolver.nameservers = nameservers
 
     def log_info(self, message, *args):
         """Log an info message or print to stdout if logger is not available."""
-        if self.logger:
-            self.logger.info(message, *args)
+        logger = self.env_manager.get_logger()
+        if logger:
+            logger.info(message, *args)
         else:
             print(f"INFO: {message % args}")
+
+    def get_csp_ip_addresses(self):
+        """returns the csp ip address class"""
+        return self.csp_ip_addresses
 
     def get_resolver(self):
         """Retrieve DNS resolver."""
@@ -140,209 +82,22 @@ class DomainProcessingContext:
         """Set current Domain to be processed."""
         self.current_domain = domain
 
-    def get_nameservers(self):
-        """Get list of nameservers for DNS resolution."""
-        return self.nameservers
-
-    def set_nameservers(self, nameservers):
-        """Set list of nameservers for DNS resolution."""
-        self.nameservers = nameservers
-
-    def get_output_files(self):
-        """Get list of output files to write the results to."""
-        return self.output_files
-
-    def set_output_files(self, output_files):
-        """Set list of output files to write the results to."""
-        self.output_files = output_files
-
-    def get_verbose(self):
-        """
-        Get the status of the verbose mode.
-        """
-        return self.verbose
-
-    def set_verbose(self, verbose):
-        """
-        Set the status of the verbose mode.
-        """
-        self.verbose = verbose
-
-    def get_extreme(self):
-        """
-        Get the status of the extreme mode.
-        """
-        return self.extreme
-
-    def set_extreme(self, extreme):
-        """
-        Set the status of the extreme mode.
-        """
-        self.extreme = extreme
-
-    def set_gcp_ip(self, gcp_ipv4, gcp_ipv6):
-        """
-        Set both IPv4 and IPv6 addresses of Google Cloud Platform.
-        """
-        self.gcp_ipv4 = gcp_ipv4
-        self.gcp_ipv6 = gcp_ipv6
-
-    def get_gcp_ipv6(self):
-        """
-        Retrieve the Google Cloud Platform IPV6 address.
-        """
-        return self.gcp_ipv6
-
-    def get_gcp_ipv4(self):
-        """
-        Retrieve the Google Cloud Platform IPV4 address.
-        """
-        return self.gcp_ipv6
-
-    def get_aws_ipv4(self):
-        """
-        Get the Amazon Web Services IPV4 address.
-        """
-        return self.aws_ipv4
-
-    def get_aws_ipv6(self):
-        """
-        Get the Amazon Web Services IPV4 address.
-        """
-        return self.aws_ipv6
-
-    def set_aws_ip(self, aws_ipv4, aws_ipv6):
-        """
-        Set both IPv4 and IPv6 addresses of Amazon Web Services.
-        """
-        self.aws_ipv4 = aws_ipv4
-        self.aws_ipv6 = aws_ipv6
-
-    def set_azure_ip(self, azure_ipv4, azure_ipv6):
-        """
-        Set both IPv4 and IPv6 addresses of Microsoft Azure.
-        """
-        self.azure_ipv4 = azure_ipv4
-        self.azure_ipv6 = azure_ipv6
-
-    def get_azure_ipv4(self):
-        """
-        Get the Microsoft Azure IPV4 address.
-        """
-        return self.azure_ipv4
-
-    def get_azure_ipv6(self):
-        """
-        Get the Microsoft Azure IPV6 address.
-        """
-        return self.azure_ipv6
-
-    def set_azure_ipv6(self, azure_ipv6):
-        """
-        Sets the Azure IPV6.
-        """
-        self.azure_ipv6 = azure_ipv6
-
-    def get_perform_service_checks(self):
-        """
-        Get the status of service checks.
-        """
-        return self.perform_service_checks
-
-    def set_perform_service_checks(self, perform_service_checks):
-        """
-        Sets the status of service checks.
-        """
-        self.perform_service_checks = perform_service_checks
-
-    def get_timeout(self):
-        """
-        Get DNS resolution timeout value.
-        """
-        return self.timeout
-
-    def set_timeout(self, timeout):
-        """
-        Set the DNS resolution timeout value.
-        """
-        self.timeout = timeout
-
-    def get_retries(self):
-        """
-        Get number of retries for DNS resolution.
-        """
-        return self.retries
-
-    def set_retries(self, retries):
-        """
-        Set the retries for DNS resolution.
-        """
-        self.retries = retries
-
-    def get_patterns(self):
-        """
-        Get list of domain name matching patterns.
-        """
-        return self.patterns
-
-    def set_patterns(self, patterns):
-        """
-        Set the domain name matching patterns.
-        """
-        self.patterns = patterns
-
     def get_dangling_domains(self):
-        """
-        Get set of discovered dangling domains.
-        """
+        """Get set of discovered dangling domains."""
         return self.dangling_domains
 
     def set_dangling_domains(self, dangling_domains):
-        """
-        Set the set of discovered dangling domains.
-        """
+        """Set the set of discovered dangling domains."""
         self.dangling_domains = dangling_domains
 
     def add_dangling_domain_to_domains(self, domain):
-        """
-        Add a dangling domain to the set of dangling domains.
-        :param domain: Dangling domain to be added.
-        """
+        """Add a dangling domain to the set of dangling domains."""
         self.dangling_domains.add(domain)
 
     def get_failed_domains(self):
-        """
-        Get the set of failed domains.
-        """
+        """Get the set of failed domains."""
         return self.failed_domains
 
     def set_failed_domains(self, failed_domains):
-        """
-        Set the set of failed domains.
-        :param failed_domains: Set of failed domains.
-        """
+        """Set the set of failed domains."""
         self.failed_domains = failed_domains
-
-    def get_evidence_enabled(self):
-        """
-        Get the status of evidence collection.
-        """
-        return self.evidence_enabled
-
-    def set_evidence_enabled(self, evidence_enabled):
-        """
-        Set the evidence_enabled flag.
-        """
-        self.evidence_enabled = evidence_enabled
-
-    def get_logger(self):
-        """
-        Get the logger object.
-        """
-        return self.logger
-
-    def set_logger(self, logger):
-        """
-        Set the logger object.
-        """
-        self.logger = logger

--- a/classes/environment_manager.py
+++ b/classes/environment_manager.py
@@ -28,10 +28,11 @@ async def write_to_file(file_path, content):
         logger.error(f"Failed to write to {file_path}: {e}")
 
 
-def setup_logger(log_file="dnsresolver.log"):
+def setup_logger(log_file="dnsresolver.log", verbose=False):
     """
     Set up a logger for DNSResolver.
     :param log_file: The log file path.
+    :param verbose: Enable verbose mode for console logging.
     :return: Logger object.
     """
     logger = logging.getLogger("DNSResolver")
@@ -40,9 +41,9 @@ def setup_logger(log_file="dnsresolver.log"):
     if logger.hasHandlers():  # Clear any pre-existing handlers
         logger.handlers.clear()
 
-    # Create console handler with a log level of ERROR (only for errors to console)
+    # Create console handler with a log level of CRITICAL (suppresses output by default)
     ch = logging.StreamHandler()
-    ch.setLevel(logging.ERROR)  # Defaulting to ERROR to console
+    ch.setLevel(logging.CRITICAL)  # Suppress console output by default
 
     # Create file handler which logs all messages from INFO to higher
     fh = logging.FileHandler(log_file)
@@ -57,6 +58,9 @@ def setup_logger(log_file="dnsresolver.log"):
     # Add the handlers to the logger
     logger.addHandler(ch)
     logger.addHandler(fh)
+
+    if verbose:
+        ch.setLevel(logging.INFO)  # Enable console logging if verbose mode is set
 
     # Test logging to ensure it's working
     logger.info("Logger initialized.")
@@ -286,18 +290,16 @@ class EnvironmentManager:
 
     def update_logger(self):
         """
-        Updates the logger based on the verbosity supplied
+        Updates the logger based on the verbosity supplied.
         """
-        if self.args.verbose:  # If verbose flag is true
+        if self.verbose:  # If verbose flag is true
             for handler in self.logger.handlers:
                 if isinstance(handler, logging.StreamHandler):
                     handler.setLevel(logging.INFO)  # Set console logging level to INFO
         else:
             for handler in self.logger.handlers:
                 if isinstance(handler, logging.StreamHandler):
-                    handler.setLevel(
-                        logging.CRITICAL
-                    )  # Set console logging level to CRITICAL to suppress errors
+                    handler.setLevel(logging.CRITICAL)  # Suppress console logging
 
         # Test logging to verify the update
         self.logger.info("Logger updated based on verbosity.")

--- a/classes/environment_manager.py
+++ b/classes/environment_manager.py
@@ -11,11 +11,9 @@ import aiofiles
 import requests
 from requests import RequestException
 
-from classes.custom_exceptions import (
-    FileDoesNotExistError,
-    InvalidNameserversError,
-    NotAnIntegerError,
-)
+from classes.custom_exceptions import (FileDoesNotExistError,
+                                       InvalidNameserversError,
+                                       NotAnIntegerError)
 
 
 async def write_to_file(file_path, content):
@@ -116,7 +114,7 @@ class EnvironmentManager:
             "external_ip": None,
             "run_in_docker": None,
         }
-        self.domains = None
+        self.domains = set()
         self.patterns = None
 
         # Default Actions
@@ -497,7 +495,7 @@ class EnvironmentManager:
         """
         with open(self.domains_file, "r", encoding="utf-8") as f:
             raw_domains = f.read().splitlines()
-            self.domains = self.clean_domains(raw_domains)
+            self.domains = set(self.clean_domains(raw_domains))  # Convert list to set
 
     def clean_domains(self, domains):
         """

--- a/classes/evidence_collector.py
+++ b/classes/evidence_collector.py
@@ -1,0 +1,146 @@
+import asyncio
+import platform
+import subprocess
+import os
+
+
+class EvidenceCollector:
+    def __init__(self, env_manager):
+        self.env_manager = env_manager
+
+    @staticmethod
+    def check_tools_availability():
+        """
+        Check the availability of nslookup and dig tools in the system path.
+
+        :return: Tuple indicating the availability of nslookup and dig (nslookup_available, dig_available).
+        """
+        if platform.system() == "Windows":
+            nslookup_available = (
+                subprocess.run(
+                    ["where", "nslookup"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+            dig_available = (
+                subprocess.run(
+                    ["where", "dig"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+        else:
+            nslookup_available = (
+                subprocess.run(
+                    ["which", "nslookup"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+            dig_available = (
+                subprocess.run(
+                    ["which", "dig"], capture_output=True, text=True
+                ).returncode
+                == 0
+            )
+
+        return nslookup_available, dig_available
+
+    async def save_and_log_dns_result(
+        self, result, domain, nameserver, reason, evidence_dir, command_name
+    ):
+        """
+        Save and log the result of a DNS query command.
+
+        :param result: The subprocess result object.
+        :param domain: The domain name queried.
+        :param nameserver: The nameserver used for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :param command_name: The name of the DNS query command (e.g., nslookup, dig).
+        :return: None
+        """
+        stdout, stderr = await result.communicate()
+        content = stdout.decode() + "\n" + stderr.decode()
+        filename = os.path.join(evidence_dir, f"{domain}_{reason}_{nameserver}.txt")
+        await self.env_manager.write_to_file(filename, content)
+        self.env_manager.log_info(
+            f"{command_name} result saved for domain {domain} using nameserver {nameserver}"
+        )
+
+    async def perform_nslookup(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using the nslookup command and save the output to a file.
+
+        :param domain: The domain name to query.
+        :param nameserver: The nameserver to use for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :return: None
+        """
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "nslookup",
+                domain,
+                nameserver,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await self.save_and_log_dns_result(
+                result, domain, nameserver, reason, evidence_dir, "nslookup"
+            )
+        except Exception as e:
+            self.env_manager.log_error(f"Command failed with error: {e}")
+            raise e from None
+
+    async def perform_dig(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using the dig command and save the output to a file.
+
+        :param domain: The domain name to query.
+        :param nameserver: The nameserver to use for the query.
+        :param reason: The reason for performing the query.
+        :param evidence_dir: The directory to save the evidence file.
+        :return: None
+        """
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "dig",
+                f"@{nameserver}",
+                domain,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await self.save_and_log_dns_result(
+                result, domain, nameserver, reason, evidence_dir, "dig"
+            )
+        except Exception as e:
+            self.env_manager.log_error(f"Command failed with error: {e}")
+            raise e from None
+
+    async def perform_dns_evidence(self, domain, nameserver, reason, evidence_dir):
+        """
+        Perform a DNS lookup using either nslookup or dig, depending on the system.
+
+        :param domain: The domain name to perform the DNS lookup for.
+        :param nameserver: The nameserver to use for the DNS lookup.
+        :param reason: The reason for performing the DNS lookup.
+        :param evidence_dir: The directory where the output file will be saved.
+        :return: None
+        """
+        nslookup_available, dig_available = self.check_tools_availability()
+
+        if platform.system() == "Windows":
+            if nslookup_available:
+                await self.perform_nslookup(domain, nameserver, reason, evidence_dir)
+            else:
+                self.env_manager.log_error(
+                    f"nslookup not available on Windows system for domain {domain}"
+                )
+        else:
+            if dig_available:
+                await self.perform_dig(domain, nameserver, reason, evidence_dir)
+            elif nslookup_available:
+                await self.perform_nslookup(domain, nameserver, reason, evidence_dir)
+            else:
+                self.env_manager.log_error(
+                    f"Neither dig nor nslookup available on non-Windows system for domain {domain}"
+                )

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
         "max_threads": 2,
         "timeout": 1,
 	    "nameservers": "1.1.1.1,8.8.8.8",
-        "verbose": true,
+        "verbose": false,
         "retries": 2,
         "evidence": true,
         "service_checks": true,

--- a/imports/cloud_service_provider_checks.py
+++ b/imports/cloud_service_provider_checks.py
@@ -62,8 +62,12 @@ def perform_csp_checks(domain_context, env_manager, final_ips):
     vendor_ips_context_ipv4 = get_vendor_ips(domain_context, ip_version=4)
     vendor_ips_context_ipv6 = get_vendor_ips(domain_context, ip_version=6)
 
-    matches_ipv4 = get_ip_matches(final_ips, vendor_ips_context_ipv4, domain_context, ip_version=4)
-    matches_ipv6 = get_ip_matches(final_ips, vendor_ips_context_ipv6, domain_context, ip_version=6)
+    matches_ipv4 = get_ip_matches(
+        final_ips, vendor_ips_context_ipv4, domain_context, ip_version=4
+    )
+    matches_ipv6 = get_ip_matches(
+        final_ips, vendor_ips_context_ipv6, domain_context, ip_version=6
+    )
 
     matches = merge_matches(matches_ipv4, matches_ipv6, vendor_ips_context_ipv4)
 
@@ -72,7 +76,8 @@ def perform_csp_checks(domain_context, env_manager, final_ips):
     for vendor, matched_ips in matches.items():
         if matched_ips:
             success = (
-                log_and_write(vendor, matched_ips, domain, output_files, domain_context) or success
+                log_and_write(vendor, matched_ips, domain, output_files, domain_context)
+                or success
             )
         else:
             domain_context.log_info(f"No cloud IPs were resolved for {vendor}")
@@ -84,24 +89,25 @@ def get_vendor_ips(domain_context, ip_version):
     """
     Get vendor IP ranges based on IP version.
 
-    :param domain_context: An instance of DomainProcessingContext
-    :type domain_context: DomainProcessingContext
-    :param ip_version: IP version (4 or 6)
-    :type ip_version: int
-    :return: Dictionary of vendor IP ranges
-    :rtype: dict
+    :param domain_context: An instance of DomainProcessingContext.
+    :type domain_context: DomainProcessingContext.
+    :param ip_version: IP version (4 or 6).
+    :type ip_version: int.
+    :return: Dictionary of vendor IP ranges.
+    :rtype: dict.
     """
+    csp_ip_addresses = domain_context.get_csp_ip_addresses()
     if ip_version == 4:
         return {
-            "gcp": domain_context.get_gcp_ipv4(),
-            "aws": domain_context.get_aws_ipv4(),
-            "azure": domain_context.get_azure_ipv4(),
+            "gcp": csp_ip_addresses.get_gcp_ipv4(),
+            "aws": csp_ip_addresses.get_aws_ipv4(),
+            "azure": csp_ip_addresses.get_azure_ipv4(),
         }
     if ip_version == 6:
         return {
-            "gcp": domain_context.get_gcp_ipv6(),
-            "aws": domain_context.get_aws_ipv6(),
-            "azure": domain_context.get_azure_ipv6(),
+            "gcp": csp_ip_addresses.get_gcp_ipv6(),
+            "aws": csp_ip_addresses.get_aws_ipv6(),
+            "azure": csp_ip_addresses.get_azure_ipv6(),
         }
     return {}
 
@@ -125,7 +131,9 @@ def get_ip_matches(final_ips, vendor_ips_context, domain_context, ip_version):
     for ip in final_ips:
         if not is_ip_version(ip, ip_version):
             continue
-        ip_obj = ipaddress.IPv4Address(ip) if ip_version == 4 else ipaddress.IPv6Address(ip)
+        ip_obj = (
+            ipaddress.IPv4Address(ip) if ip_version == 4 else ipaddress.IPv6Address(ip)
+        )
         match_ip_with_vendors(ip_obj, vendor_ips_context, domain_context, matches)
     return matches
 
@@ -184,7 +192,8 @@ def merge_matches(matches_ipv4, matches_ipv6, vendor_ips_context):
     :rtype: dict
     """
     return {
-        vendor: list(matches_ipv4[vendor] | matches_ipv6[vendor]) for vendor in vendor_ips_context
+        vendor: list(matches_ipv4[vendor] | matches_ipv6[vendor])
+        for vendor in vendor_ips_context
     }
 
 
@@ -214,6 +223,7 @@ def log_and_write(vendor, matched_ips, domain, output_files, domain_context):
             file.write(message + "\n")
 
         domain_context.log_info(message)
+
         return True
     return False
 

--- a/imports/create_domain_context.py
+++ b/imports/create_domain_context.py
@@ -1,0 +1,38 @@
+"""
+Module: domain_context
+----------------------
+
+This module provides functionality for creating and initializing the domain context
+used in DNS resolution and domain analysis workflows.
+
+Classes:
+    - DomainProcessingContext
+
+Functions:
+    - create_domain_context: Initializes a DomainProcessingContext instance for a given domain.
+"""
+
+from classes.domain_processing_context import DomainProcessingContext
+
+
+def create_domain_context(
+    domain, env_manager, dangling_domains, failed_domains, csp_ip_addresses
+):
+    """
+    Initializes a DomainProcessingContext instance for a given domain.
+
+    Args:
+        domain (str): The domain name to be processed.
+        env_manager (EnvironmentManager): The environment manager instance.
+        dangling_domains (set): Set to store dangling domains.
+        failed_domains (set): Set to store failed domains.
+        csp_ip_addresses (CSPIPAddresses): Instance containing CSP IP ranges.
+
+    Returns:
+        DomainProcessingContext: Initialized context for the given domain.
+    """
+    domain_context = DomainProcessingContext(env_manager, csp_ip_addresses)
+    domain_context.set_domain(domain)
+    domain_context.dangling_domains = dangling_domains
+    domain_context.failed_domains = failed_domains
+    return domain_context

--- a/imports/dns_based_checks.py
+++ b/imports/dns_based_checks.py
@@ -15,13 +15,6 @@ async def perform_dns_checks_async(domain_context, env_manager, final_ips):
     current_domain = domain_context.get_domain()
     output_files = env_manager.get_output_files()
 
-    random_nameserver = env_manager.get_random_nameserver()
-    if random_nameserver:
-        handler.resolver.nameservers = [random_nameserver]
-        env_manager.log_info(
-            f"Using nameserver {random_nameserver} for DNS checks on {domain_context.get_domain()}"
-        )
-
     if final_ips:
         await env_manager.write_to_file(
             output_files["standard"]["resolved"],

--- a/imports/dns_based_checks.py
+++ b/imports/dns_based_checks.py
@@ -1,261 +1,23 @@
-import asyncio
-import json
-import os
-import platform
-import re
-import subprocess
-
-import aiodns
-import aiofiles
-
-
-async def load_domain_categorisation_patterns(config_file="config.json"):
-    """
-    Load domain categorization patterns from the given config file.
-
-    :param config_file: The path to the config file. Defaults to "config.json".
-    :type config_file: str
-    :return: A dictionary of domain categorization patterns.
-    :rtype: dict
-    """
-    with open(config_file, "r", encoding="utf-8") as f:
-        config = json.load(f)
-    return config.get("domain_categorization", {})
-
-
-def categorise_domain(domain, patterns):
-    """
-    Categorizes a domain based on a set of patterns.
-    :param domain: The domain to categorize.
-    :param patterns: A dictionary containing patterns to match against the domain.
-                     Should have the following structure:
-                     {
-                         category1: {
-                             "regex": pattern1,
-                             "recommendation": recommendation1,
-                             "evidence": evidence1
-                         },
-                         category2: {
-                             "regex": pattern2,
-                             "recommendation": recommendation2,
-                             "evidence": evidence2
-                         },
-                         ...
-                     }
-    """
-    for category, pattern in patterns.items():
-        if re.search(pattern["regex"], domain):
-            return category, pattern["recommendation"], pattern["evidence"]
-    return "unknown", "Unclassified", "N/A"
-
-
-async def is_dangling_record_async(resolver, domain, record_type):
-    """
-    Asynchronously checks if a specified DNS record for a given domain is a dangling record or not.
-    """
-    try:
-        await resolver.query(domain, record_type)
-        return False
-    except aiodns.error.DNSError as e:
-        if e.args[0] in [3, 4]:  # NXDOMAIN (Domain name not found) or SERVFAIL
-            return True
-        return False
-
-
-def check_tools_availability():
-    """
-    Check the availability of nslookup and dig tools in the system path.
-    :return: Tuple indicating the availability of nslookup and dig (nslookup_available, dig_available)
-    """
-    if platform.system() == "Windows":
-        nslookup_available = (
-            subprocess.run(
-                ["where", "nslookup"], capture_output=True, text=True
-            ).returncode
-            == 0
-        )
-        dig_available = (
-            subprocess.run(["where", "dig"], capture_output=True, text=True).returncode
-            == 0
-        )
-    else:
-        nslookup_available = (
-            subprocess.run(
-                ["which", "nslookup"], capture_output=True, text=True
-            ).returncode
-            == 0
-        )
-        dig_available = (
-            subprocess.run(["which", "dig"], capture_output=True, text=True).returncode
-            == 0
-        )
-
-    return nslookup_available, dig_available
-
-
-def log_error(message):
-    """
-    Log an error message to the log file.
-    :param message: The error message to log.
-    :return: None
-    """
-    with open("error.log", "a", encoding="utf-8") as f:
-        f.write(f"{message}\n")
-
-
-async def resolve_domain_async(domain_context, env_manager):
-    """
-    Asynchronously resolves a domain and returns a success status and the final IP addresses.
-    """
-    resolved_records = []
-    current_domain = domain_context.get_domain()
-    resolver = aiodns.DNSResolver()
-    random_nameserver = env_manager.get_random_nameserver()
-
-    if random_nameserver:
-        resolver.nameservers = [random_nameserver]
-        env_manager.log_info(
-            f"Using nameserver {random_nameserver} for resolving {current_domain}"
-        )
-
-    try:
-        answers = await resolver.query(current_domain, "A")
-        final_ips = [answer.host for answer in answers]
-        resolved_records.append(("A", final_ips))
-
-        is_dangling = await check_dangling_cname_async(
-            domain_context, env_manager, current_domain
-        )
-        if is_dangling:
-            domain_context.add_dangling_domain_to_domains(current_domain)
-
-        return True, final_ips
-    except aiodns.error.DNSError as e:
-        if e.args[0] == 4:  # NXDOMAIN (Domain name not found)
-            env_manager.log_info(
-                f"{current_domain} not found, checking for dangling CNAME."
-            )
-            is_dangling = await check_dangling_cname_async(
-                domain_context, env_manager, current_domain
-            )
-            if is_dangling:
-                domain_context.add_dangling_domain_to_domains(current_domain)
-                return True, []
-        elif e.args[0] == 11:  # Could not contact DNS servers
-            env_manager.log_error(f"DNS resolution error for {current_domain}: {e}")
-            await env_manager.write_to_file(
-                env_manager.get_output_files()["standard"]["unresolved"],
-                f"{current_domain}|Could not contact DNS servers",
-            )
-        else:
-            env_manager.log_error(f"DNS resolution error for {current_domain}: {e}")
-            await env_manager.write_to_file(
-                env_manager.get_output_files()["standard"]["unresolved"],
-                f"{current_domain}|{e}",
-            )
-        return False, []
-
-
-async def save_and_log_dns_result(
-    result, domain, nameserver, reason, evidence_dir, env_manager, command_name
-):
-    stdout, stderr = await result.communicate()
-    content = stdout.decode() + "\n" + stderr.decode()
-    filename = os.path.join(evidence_dir, f"{domain}_{reason}_{nameserver}.txt")
-    await env_manager.write_to_file(filename, content)
-    env_manager.log_info(
-        f"{command_name} result saved for domain {domain} using nameserver {nameserver}"
-    )
-
-
-async def perform_nslookup(domain, nameserver, reason, evidence_dir, env_manager):
-    """
-    Perform a DNS lookup using the nslookup command and save the output to a file.
-    """
-    try:
-        result = await asyncio.create_subprocess_exec(
-            "nslookup",
-            domain,
-            nameserver,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        await save_and_log_dns_result(
-            result, domain, nameserver, reason, evidence_dir, env_manager, "nslookup"
-        )
-    except Exception as e:
-        env_manager.log_error(f"Command failed with error: {e}")
-        raise e from None
-
-
-async def perform_dig(domain, nameserver, reason, evidence_dir, env_manager):
-    """
-    Perform a DNS lookup using the dig command and save the output to a file.
-    """
-    try:
-        result = await asyncio.create_subprocess_exec(
-            "dig",
-            f"@{nameserver}",
-            domain,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        await save_and_log_dns_result(
-            result, domain, nameserver, reason, evidence_dir, env_manager, "dig"
-        )
-    except Exception as e:
-        env_manager.log_error(f"Command failed with error: {e}")
-        raise e from None
-
-
-async def perform_dns_evidence(domain, nameserver, reason, evidence_dir, env_manager):
-    """
-    Perform a DNS lookup using either nslookup or dig, depending on the system.
-
-    :param domain: The domain name to perform the DNS lookup for.
-    :param nameserver: The nameserver to use for the DNS lookup.
-    :param reason: The reason for performing the DNS lookup.
-    :param evidence_dir: The directory where the output file will be saved.
-    :param env_manager: The environment manager instance for logging.
-    :return: None
-    """
-    nslookup_available, dig_available = check_tools_availability()
-
-    if platform.system() == "Windows":
-        if nslookup_available:
-            await perform_nslookup(
-                domain, nameserver, reason, evidence_dir, env_manager
-            )
-        else:
-            env_manager.log_error(
-                f"nslookup not available on Windows system for domain {domain}"
-            )
-    else:
-        if dig_available:
-            await perform_dig(domain, nameserver, reason, evidence_dir, env_manager)
-        elif nslookup_available:
-            await perform_nslookup(
-                domain, nameserver, reason, evidence_dir, env_manager
-            )
-        else:
-            env_manager.log_error(
-                f"Neither dig nor nslookup available on non-Windows system for domain {domain}"
-            )
+from classes.dns_handler import DNSHandler
 
 
 async def perform_dns_checks_async(domain_context, env_manager, final_ips):
     """
     Performs DNS checks and evidence collection if enabled.
+
+    :param domain_context: The domain context instance.
+    :param env_manager: The environment manager instance for logging and configuration.
+    :param final_ips: The final IP addresses resolved for the domain.
+    :return: None
     """
-    resolver = aiodns.DNSResolver()
+    handler = DNSHandler(env_manager)
     patterns = env_manager.get_patterns()
     current_domain = domain_context.get_domain()
     output_files = env_manager.get_output_files()
-    evidence_enabled = env_manager.get_evidence()
 
     random_nameserver = env_manager.get_random_nameserver()
     if random_nameserver:
-        resolver.nameservers = [random_nameserver]
+        handler.resolver.nameservers = [random_nameserver]
         env_manager.log_info(
             f"Using nameserver {random_nameserver} for DNS checks on {domain_context.get_domain()}"
         )
@@ -267,17 +29,9 @@ async def perform_dns_checks_async(domain_context, env_manager, final_ips):
         )
         env_manager.log_info(f"Resolved IPs for domain {current_domain}: {final_ips}")
 
-    if evidence_enabled:
-        for nameserver in env_manager.get_resolvers():
-            await perform_dns_evidence(
-                current_domain,
-                nameserver,
-                "dangling",
-                output_files["evidence"]["dns"],
-                env_manager,
-            )
+    await handler.collect_evidence(current_domain, "dangling", output_files)
 
-    category, recommendation, evidence_link = categorise_domain(
+    category, recommendation, evidence_link = handler.categorise_domain(
         current_domain, patterns
     )
     await env_manager.write_to_file(
@@ -287,56 +41,3 @@ async def perform_dns_checks_async(domain_context, env_manager, final_ips):
     env_manager.log_info(
         f"Categorised domain {current_domain} as {category} with recommendation: {recommendation}"
     )
-
-
-async def check_dangling_cname_async(domain_context, env_manager, current_domain):
-    """
-    Asynchronously checks if a domain is a dangling CNAME, returning a boolean result.
-    """
-    resolver = aiodns.DNSResolver()
-    original_domain = domain_context.get_domain()
-    output_files = env_manager.get_output_files()
-    evidence_enabled = env_manager.get_evidence()
-
-    random_nameserver = env_manager.get_random_nameserver()
-    if random_nameserver:
-        resolver.nameservers = [random_nameserver]
-        env_manager.log_info(
-            f"Using nameserver {random_nameserver} for resolving {current_domain}"
-        )
-
-    for record_type in ["A", "AAAA", "MX"]:
-        if not await is_dangling_record_async(resolver, current_domain, record_type):
-            return False
-
-    if not await is_dangling_record_async(resolver, current_domain, "NS"):
-        await env_manager.write_to_file(
-            output_files["standard"]["ns_takeover"],
-            f"{original_domain}|{current_domain}",
-        )
-        env_manager.log_info(f"NS takeover possible for domain {current_domain}")
-        return False
-
-    patterns = env_manager.get_patterns()
-    category, recommendation, evidence_link = categorise_domain(
-        current_domain, patterns
-    )
-    await env_manager.write_to_file(
-        output_files["standard"]["dangling"],
-        f"{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}",
-    )
-    env_manager.log_info(
-        f"Domain {current_domain} is a dangling CNAME with category: {category}"
-    )
-
-    if evidence_enabled:
-        for nameserver in env_manager.get_resolvers():
-            await perform_dns_evidence(
-                current_domain,
-                nameserver,
-                "dangling",
-                output_files["evidence"]["dns"],
-                env_manager,
-            )
-
-    return True

--- a/imports/dns_based_checks.py
+++ b/imports/dns_based_checks.py
@@ -141,9 +141,19 @@ async def resolve_domain_async(domain_context, env_manager):
             if is_dangling:
                 domain_context.add_dangling_domain_to_domains(current_domain)
                 return True, []
+        elif e.args[0] == 11:  # Could not contact DNS servers
+            env_manager.log_error(f"DNS resolution error for {current_domain}: {e}")
+            await env_manager.write_to_file(
+                env_manager.get_output_files()["standard"]["unresolved"],
+                f"{current_domain}|Could not contact DNS servers",
+            )
         else:
             env_manager.log_error(f"DNS resolution error for {current_domain}: {e}")
-            return False, []
+            await env_manager.write_to_file(
+                env_manager.get_output_files()["standard"]["unresolved"],
+                f"{current_domain}|{e}",
+            )
+        return False, []
 
 
 async def save_and_log_dns_result(

--- a/imports/domain_processor.py
+++ b/imports/domain_processor.py
@@ -17,9 +17,8 @@ Functions:
 
 from imports.cloud_service_provider_checks import perform_csp_checks
 from imports.create_domain_context import create_domain_context
-from imports.dns_based_checks import resolve_domain_async
-from imports.service_connectivity_checks import \
-    perform_service_connectivity_checks
+from classes.dns_handler import DNSHandler
+from imports.service_connectivity_checks import perform_service_connectivity_checks
 
 
 async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses):
@@ -30,7 +29,8 @@ async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses):
 
     env_manager.log_info(f"Processing domain: {domain}")
 
-    success, final_ips = await resolve_domain_async(domain_context, env_manager)
+    handler = DNSHandler(env_manager)
+    success, final_ips = await handler.resolve_domain_async(domain_context)
 
     env_manager.log_info(
         f"Processing domain: {domain} was {'successful' if success else 'unsuccessful'}"

--- a/imports/domain_processor.py
+++ b/imports/domain_processor.py
@@ -18,7 +18,8 @@ Functions:
 from imports.cloud_service_provider_checks import perform_csp_checks
 from imports.create_domain_context import create_domain_context
 from imports.dns_based_checks import resolve_domain_async
-from imports.service_connectivity_checks import perform_service_connectivity_checks
+from imports.service_connectivity_checks import \
+    perform_service_connectivity_checks
 
 
 async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses):

--- a/imports/domain_processor.py
+++ b/imports/domain_processor.py
@@ -17,11 +17,10 @@ Functions:
 
 from imports.cloud_service_provider_checks import perform_csp_checks
 from imports.create_domain_context import create_domain_context
-from classes.dns_handler import DNSHandler
 from imports.service_connectivity_checks import perform_service_connectivity_checks
 
 
-async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses):
+async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses, dns_handler):
     domain_context = create_domain_context(
         domain, env_manager, set(), set(), csp_ip_addresses
     )
@@ -29,8 +28,7 @@ async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses):
 
     env_manager.log_info(f"Processing domain: {domain}")
 
-    handler = DNSHandler(env_manager)
-    success, final_ips = await handler.resolve_domain_async(domain_context)
+    success, final_ips = await dns_handler.resolve_domain_async(domain_context)
 
     env_manager.log_info(
         f"Processing domain: {domain} was {'successful' if success else 'unsuccessful'}"

--- a/imports/domain_processor.py
+++ b/imports/domain_processor.py
@@ -48,4 +48,4 @@ async def process_domain_async(domain, env_manager, pbar, csp_ip_addresses, dns_
         f"Finished processing domain: {domain_context.get_domain()}"
     )
 
-    return success, final_ips
+    return success, final_ips, domain_context.dangling_domains

--- a/imports/service_connectivity_checks.py
+++ b/imports/service_connectivity_checks.py
@@ -36,12 +36,9 @@ import os
 import re
 import socket
 import ssl
-from concurrent.futures import (
-    CancelledError,
-    ThreadPoolExecutor,
-    TimeoutError as CfTimeoutError,
-    as_completed,
-)
+from concurrent.futures import CancelledError, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as CfTimeoutError
+from concurrent.futures import as_completed
 
 import requests
 from selenium import webdriver

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ requests>=2.28.1
 tqdm>=4.64.1
 argparse~=1.4.0
 selenium~=4.22.0
-urllib3==1.26.6
+aiodns~=3.2.0
+aiofiles~=24.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ argparse~=1.4.0
 selenium~=4.22.0
 aiodns~=3.2.0
 aiofiles~=24.1.0
+
+# dev / test
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/resolver.py
+++ b/resolver.py
@@ -1,18 +1,4 @@
-"""
-This python module resolves DNS records for a given list of domains
-and checks them against the known IP ranges of major cloud providers
-(AWS, GCP, and Azure).
-
-This script handles multithreading for DNS resolutions and provides
-different verbose levels for extra logging (default, verbose, and extreme).
-The results of DNS resolution and Cloud IPs matching are stored in the specified
-output directory.
-
-The script can be run directly with the use of command-line arguments for
-specifying the domains file, output directory, verbosity mode and custom resolvers.
-"""
-
-import threading
+import asyncio
 
 from tqdm import tqdm
 
@@ -23,102 +9,66 @@ from imports.cloud_ip_ranges import (
     fetch_azure_ip_ranges,
     fetch_google_cloud_ip_ranges,
 )
-from imports.dns_based_checks import load_domain_categorisation_patterns
-from imports.domain_processor import process_domain
+from imports.domain_processor import process_domain_async
+from classes.csp_ip_addresses import CSPIPAddresses
 
 
-def main():
-    """
-    Main function of the program.
-    Processes domain names and retrieves IP ranges from Google Cloud, AWS, and Azure.
-    Resolves domain names and performs various checks on them.
-    Prints final messages and results.
-
-    :return: None
-    """
+async def main_async():
     env_manager = EnvironmentManager()
-    # env_manager.parse_arguments()
 
     gcp_ipv4, gcp_ipv6 = fetch_google_cloud_ip_ranges(
         env_manager.get_output_dir(), env_manager.extreme
     )
-    aws_ipv4, aws_ipv6 = fetch_aws_ip_ranges(env_manager.get_output_dir(), env_manager.extreme)
+    aws_ipv4, aws_ipv6 = fetch_aws_ip_ranges(
+        env_manager.get_output_dir(), env_manager.extreme
+    )
     azure_ipv4, azure_ipv6 = fetch_azure_ip_ranges(
         env_manager.get_output_dir(), env_manager.extreme
     )
 
+    csp_ip_addresses = CSPIPAddresses(
+        gcp_ipv4, gcp_ipv6, aws_ipv4, aws_ipv6, azure_ipv4, azure_ipv6
+    )
+
     env_manager.set_domains()
 
-    if env_manager.verbose:
-        env_manager.get_logger().info("Domains to process: %s", env_manager.get_domains())
-
-    patterns = load_domain_categorisation_patterns(env_manager.get_config_file())
-
-    max_threads = env_manager.max_threads or 10
-
-    dangling_domains = set()
-    failed_domains = set(env_manager.get_domains())
-
     for attempt in range(env_manager.retries + 1):
-        if not failed_domains:
+        if not env_manager.domains:
             break
 
-        current_failed_domains = list(failed_domains)
-        failed_domains.clear()
+        current_failed_domains = list(env_manager.domains)
+        env_manager.domains.clear()
 
         with tqdm(
             total=len(current_failed_domains),
             desc=f"Processing Domains (Attempt {attempt + 1})",
         ) as pbar:
-            threads = []
+            tasks = [
+                process_domain_async(domain, env_manager, pbar, csp_ip_addresses)
+                for domain in current_failed_domains
+            ]
+            results = await asyncio.gather(*tasks)
 
-            for domain in current_failed_domains:
-                if env_manager.verbose:
-                    env_manager.log_info(f"Starting thread for domain: {domain}")
-                if len(threads) >= max_threads:
-                    threads.pop(0).join()
+        for success, final_ips in results:
+            if not success:
+                env_manager.domains.update(current_failed_domains)
 
-                domain_context = DomainProcessingContext(env_manager)
-                domain_context.set_domain(domain)
-                domain_context.set_nameservers(env_manager.get_resolvers())
-                domain_context.set_output_files(env_manager.get_output_files())
-                domain_context.set_verbose(env_manager.get_verbose())
-                domain_context.set_extreme(env_manager.get_extreme())
-                domain_context.set_gcp_ip(gcp_ipv4, gcp_ipv6)
-                domain_context.set_aws_ip(aws_ipv4, aws_ipv6)
-                domain_context.set_azure_ip(azure_ipv4, azure_ipv6)
-                domain_context.set_perform_service_checks(env_manager.get_service_checks())
-                domain_context.set_timeout(env_manager.get_timeout())
-                domain_context.set_retries(env_manager.get_retries())
-                domain_context.set_patterns(patterns)
-                domain_context.set_dangling_domains(dangling_domains)
-                domain_context.set_failed_domains(failed_domains)
-                domain_context.set_evidence_enabled(env_manager.get_evidence())
-                domain_context.set_logger(env_manager.get_logger())
-
-                thread = threading.Thread(
-                    target=process_domain,
-                    args=(domain_context, env_manager, pbar),
-                )
-                threads.append(thread)
-                thread.start()
-
-            for thread in threads:
-                thread.join()
-
-    # Print final messages
     env_manager.log_info(
         "All resolutions completed. Results saved to %s", env_manager.get_output_dir()
     )
 
     if env_manager.get_extreme():
-        env_manager.log_info("AWS IPv4 Ranges: %s", aws_ipv4)
-        env_manager.log_info("AWS IPv6 Ranges: %s", aws_ipv6)
-        env_manager.log_info("Google Cloud IPv4 Ranges: %s", gcp_ipv4)
-        env_manager.log_info("Google Cloud IPv6 Ranges: %s", gcp_ipv6)
-        env_manager.log_info("Azure IPv4 Ranges: %s", azure_ipv4)
-        env_manager.log_info("Azure IPv6 Ranges: %s", azure_ipv6)
+        env_manager.log_info("AWS IPv4 Ranges: %s", csp_ip_addresses.get_aws_ipv4())
+        env_manager.log_info("AWS IPv6 Ranges: %s", csp_ip_addresses.get_aws_ipv6())
+        env_manager.log_info(
+            "Google Cloud IPv4 Ranges: %s", csp_ip_addresses.get_gcp_ipv4()
+        )
+        env_manager.log_info(
+            "Google Cloud IPv6 Ranges: %s", csp_ip_addresses.get_gcp_ipv6()
+        )
+        env_manager.log_info("Azure IPv4 Ranges: %s", csp_ip_addresses.get_azure_ipv4())
+        env_manager.log_info("Azure IPv6 Ranges: %s", csp_ip_addresses.get_azure_ipv6())
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main_async())

--- a/resolver.py
+++ b/resolver.py
@@ -34,6 +34,13 @@ async def main_async():
     domains_to_process = list(env_manager.domains)
     retries = env_manager.get_retries()
     dns_handler = DNSHandler(env_manager)
+    sem = asyncio.Semaphore(env_manager.max_threads or 50)
+
+    async def bounded_process(domain, pbar):
+        async with sem:
+            return await process_domain_async(
+                domain, env_manager, pbar, csp_ip_addresses, dns_handler
+            )
 
     for attempt in range(retries + 1):
         if not domains_to_process:
@@ -43,10 +50,7 @@ async def main_async():
             total=len(domains_to_process),
             desc=f"Processing Domains (Attempt {attempt + 1} of {retries + 1})",
         ) as pbar:
-            tasks = [
-                process_domain_async(domain, env_manager, pbar, csp_ip_addresses, dns_handler)
-                for domain in domains_to_process
-            ]
+            tasks = [bounded_process(domain, pbar) for domain in domains_to_process]
             results = await asyncio.gather(*tasks)
 
         domains_to_process = [

--- a/resolver.py
+++ b/resolver.py
@@ -30,24 +30,42 @@ async def main_async():
     )
 
     env_manager.set_domains()
-    current_domains = list(env_manager.domains)
-    failed_domains = set()
+    domains_to_process = list(env_manager.domains)
+    retries = env_manager.get_retries()
 
-    with tqdm(
-        total=len(current_domains),
-        desc=f"Processing Domains",
-    ) as pbar:
-        tasks = [
-            process_domain_async(domain, env_manager, pbar, csp_ip_addresses)
-            for domain in current_domains
+    for attempt in range(retries + 1):
+        if not domains_to_process:
+            break
+
+        with tqdm(
+            total=len(domains_to_process),
+            desc=f"Processing Domains (Attempt {attempt + 1} of {retries + 1})",
+        ) as pbar:
+            tasks = [
+                process_domain_async(domain, env_manager, pbar, csp_ip_addresses)
+                for domain in domains_to_process
+            ]
+            results = await asyncio.gather(*tasks)
+
+        domains_to_process = [
+            domain
+            for domain, (success, _) in zip(domains_to_process, results)
+            if not success
         ]
-        results = await asyncio.gather(*tasks)
 
-    for domain, (success, final_ips) in zip(current_domains, results):
-        if not success:
-            failed_domains.add(domain)
+        if domains_to_process and attempt < retries:
+            env_manager.log_info(
+                "%d domain(s) failed on attempt %d, retrying...",
+                len(domains_to_process),
+                attempt + 1,
+            )
 
-    env_manager.domains.update(failed_domains)
+    if domains_to_process:
+        env_manager.log_info(
+            "%d domain(s) could not be resolved after %d attempt(s).",
+            len(domains_to_process),
+            retries + 1,
+        )
 
     env_manager.log_info(
         "All resolutions completed. Results saved to %s", env_manager.get_output_dir()

--- a/resolver.py
+++ b/resolver.py
@@ -35,6 +35,7 @@ async def main_async():
     retries = env_manager.get_retries()
     dns_handler = DNSHandler(env_manager)
     sem = asyncio.Semaphore(env_manager.max_threads or 50)
+    all_dangling_domains: set = set()
 
     async def bounded_process(domain, pbar):
         async with sem:
@@ -53,11 +54,12 @@ async def main_async():
             tasks = [bounded_process(domain, pbar) for domain in domains_to_process]
             results = await asyncio.gather(*tasks)
 
-        domains_to_process = [
-            domain
-            for domain, (success, _) in zip(domains_to_process, results)
-            if not success
-        ]
+        failed = []
+        for domain, (success, _final_ips, dangling) in zip(domains_to_process, results):
+            all_dangling_domains.update(dangling)
+            if not success:
+                failed.append(domain)
+        domains_to_process = failed
 
         if domains_to_process and attempt < retries:
             env_manager.log_info(
@@ -71,6 +73,13 @@ async def main_async():
             "%d domain(s) could not be resolved after %d attempt(s).",
             len(domains_to_process),
             retries + 1,
+        )
+
+    if all_dangling_domains:
+        env_manager.log_info(
+            "%d dangling domain(s) detected: %s",
+            len(all_dangling_domains),
+            ", ".join(sorted(all_dangling_domains)),
         )
 
     env_manager.log_info(

--- a/resolver.py
+++ b/resolver.py
@@ -3,6 +3,7 @@ import asyncio
 from tqdm import tqdm
 
 from classes.csp_ip_addresses import CSPIPAddresses
+from classes.dns_handler import DNSHandler
 from classes.environment_manager import EnvironmentManager
 from imports.cloud_ip_ranges import (
     fetch_aws_ip_ranges,
@@ -32,6 +33,7 @@ async def main_async():
     env_manager.set_domains()
     domains_to_process = list(env_manager.domains)
     retries = env_manager.get_retries()
+    dns_handler = DNSHandler(env_manager)
 
     for attempt in range(retries + 1):
         if not domains_to_process:
@@ -42,7 +44,7 @@ async def main_async():
             desc=f"Processing Domains (Attempt {attempt + 1} of {retries + 1})",
         ) as pbar:
             tasks = [
-                process_domain_async(domain, env_manager, pbar, csp_ip_addresses)
+                process_domain_async(domain, env_manager, pbar, csp_ip_addresses, dns_handler)
                 for domain in domains_to_process
             ]
             results = await asyncio.gather(*tasks)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+"""
+Shared test fixtures.
+
+A fixture is a reusable piece of setup that pytest injects into any test
+function that names it as a parameter.  Putting them here in conftest.py
+makes them available to every test file automatically.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from classes.csp_ip_addresses import CSPIPAddresses
+
+
+# ---------------------------------------------------------------------------
+# IP range data
+# ---------------------------------------------------------------------------
+
+GCP_IPV4 = ["34.0.0.0/8", "35.0.0.0/8"]
+GCP_IPV6 = ["2600:1900::/35"]
+AWS_IPV4 = ["3.0.0.0/8", "52.0.0.0/8"]
+AWS_IPV6 = ["2600:1f00::/25"]
+AZURE_IPV4 = ["13.0.0.0/8", "20.0.0.0/8"]
+AZURE_IPV6 = ["2603:1000::/24"]
+
+
+@pytest.fixture
+def csp_ips():
+    """A real CSPIPAddresses instance populated with test ranges."""
+    return CSPIPAddresses(GCP_IPV4, GCP_IPV6, AWS_IPV4, AWS_IPV6, AZURE_IPV4, AZURE_IPV6)
+
+
+# ---------------------------------------------------------------------------
+# Fake environment manager
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_env_manager():
+    """
+    A MagicMock that stands in for EnvironmentManager.
+
+    MagicMock automatically creates attributes on demand, so you only
+    need to configure the return values your code actually reads.
+    AsyncMock is used for methods that are awaited inside async functions.
+    """
+    env = MagicMock()
+
+    # DNS / resolver config
+    env.get_random_nameserver.return_value = None
+    env.get_resolvers.return_value = ["8.8.8.8"]
+    env.get_retries.return_value = 2
+    env.get_timeout.return_value = 5
+    env.get_evidence.return_value = False
+
+    # Output files the handler writes results to
+    env.get_output_files.return_value = {
+        "standard": {
+            "dangling": "/tmp/test_dangling.txt",
+            "ns_takeover": "/tmp/test_ns_takeover.txt",
+            "unresolved": "/tmp/test_unresolved.txt",
+            "resolved": "/tmp/test_resolved.txt",
+        },
+        "evidence": {"dns": "/tmp/test_evidence/dns"},
+    }
+
+    # Domain categorisation patterns (empty → every domain is "unknown")
+    env.get_patterns.return_value = {}
+
+    # write_to_file is async, so it needs AsyncMock not MagicMock
+    env.write_to_file = AsyncMock()
+
+    # log_* are sync fire-and-forget calls — plain MagicMock is fine
+    env.log_info = MagicMock()
+    env.log_error = MagicMock()
+
+    return env

--- a/tests/test_csp_ip_addresses.py
+++ b/tests/test_csp_ip_addresses.py
@@ -1,0 +1,63 @@
+"""
+Tests for CSPIPAddresses.
+
+This is the simplest test file — no mocking, no async, just plain
+assert statements.  A good place to start if you've never written tests.
+
+Each test function is independent.  pytest discovers them automatically
+because their names start with "test_".
+"""
+
+from classes.csp_ip_addresses import CSPIPAddresses
+
+# Reuse the same test data across all tests in this file
+GCP_IPV4 = ["34.0.0.0/8", "35.0.0.0/8"]
+GCP_IPV6 = ["2600:1900::/35"]
+AWS_IPV4 = ["3.0.0.0/8"]
+AWS_IPV6 = ["2600:1f00::/25"]
+AZURE_IPV4 = ["13.0.0.0/8"]
+AZURE_IPV6 = ["2603:1000::/24"]
+
+
+def make_csp():
+    return CSPIPAddresses(GCP_IPV4, GCP_IPV6, AWS_IPV4, AWS_IPV6, AZURE_IPV4, AZURE_IPV6)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+def test_stores_all_ranges_on_construction():
+    """All six IP range lists are stored correctly."""
+    csp = make_csp()
+    assert csp.get_gcp_ipv4() == GCP_IPV4
+    assert csp.get_gcp_ipv6() == GCP_IPV6
+    assert csp.get_aws_ipv4() == AWS_IPV4
+    assert csp.get_aws_ipv6() == AWS_IPV6
+    assert csp.get_azure_ipv4() == AZURE_IPV4
+    assert csp.get_azure_ipv6() == AZURE_IPV6
+
+
+# ---------------------------------------------------------------------------
+# Individual getters — each test is narrow so a failure points to one thing
+# ---------------------------------------------------------------------------
+
+def test_gcp_ipv4_is_distinct_from_gcp_ipv6():
+    """IPv4 and IPv6 getters must not be swapped (this caught a real bug)."""
+    csp = make_csp()
+    assert csp.get_gcp_ipv4() != csp.get_gcp_ipv6()
+
+
+def test_accepts_empty_ranges():
+    """CSPIPAddresses should work fine when a provider has no ranges."""
+    csp = CSPIPAddresses([], [], [], [], [], [])
+    assert csp.get_gcp_ipv4() == []
+    assert csp.get_aws_ipv6() == []
+
+
+def test_ranges_are_returned_by_reference():
+    """Getters return the original list, not a copy — mutations are visible."""
+    original = ["10.0.0.0/8"]
+    csp = CSPIPAddresses(original, [], [], [], [], [])
+    csp.get_gcp_ipv4().append("192.168.0.0/16")
+    assert len(original) == 2

--- a/tests/test_dns_handler.py
+++ b/tests/test_dns_handler.py
@@ -1,0 +1,231 @@
+"""
+Tests for DNSHandler.
+
+Two new ideas appear here:
+
+1. Mocking network calls — instead of making real DNS queries we replace
+   aiodns.DNSResolver with a fake object whose responses we control.
+   This keeps tests fast, deterministic, and runnable offline.
+
+2. Async tests — any `async def test_*` function is run inside an asyncio
+   event loop automatically (configured via asyncio_mode = auto in pytest.ini).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiodns
+import pytest
+
+from classes.dns_handler import DNSHandler, NXDOMAIN, SERVFAIL, NO_DATA, TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_nxdomain():
+    """Create a DNSError that looks like an NXDOMAIN response."""
+    return aiodns.error.DNSError(NXDOMAIN, "Domain not found")
+
+
+def make_servfail():
+    return aiodns.error.DNSError(SERVFAIL, "Server failure")
+
+
+def make_timeout():
+    return aiodns.error.DNSError(TIMEOUT, "Query timed out")
+
+
+def make_nodata():
+    return aiodns.error.DNSError(NO_DATA, "No records of this type")
+
+
+def dns_answer(ip):
+    """A fake DNS answer object with a .host attribute."""
+    answer = MagicMock()
+    answer.host = ip
+    return answer
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a DNSHandler with all external dependencies replaced by mocks
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def handler(mock_env_manager):
+    """
+    Build a DNSHandler without touching the network.
+
+    The fixture is async so it runs inside an event loop — required because
+    aiodns.DNSResolver() calls asyncio.get_event_loop() in its __init__.
+    We patch both it and EvidenceCollector so no real I/O happens, then
+    replace the resolvers with controllable AsyncMock / MagicMock objects.
+    """
+    with patch("classes.dns_handler.EvidenceCollector"), \
+         patch("classes.dns_handler.aiodns.DNSResolver"):
+        h = DNSHandler(mock_env_manager)
+
+    # Replace with controllable fakes
+    h.aiodns_resolver = AsyncMock()
+    h.dnspython_resolver = MagicMock()
+    return h
+
+
+@pytest.fixture
+def domain_context(mock_env_manager, csp_ips):
+    """A minimal DomainProcessingContext."""
+    from classes.domain_processing_context import DomainProcessingContext
+    ctx = DomainProcessingContext(mock_env_manager, csp_ips)
+    ctx.set_domain("example.com")
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# is_dns_error_present
+# ---------------------------------------------------------------------------
+
+def test_is_dns_error_present_matches_correct_code(handler):
+    error = make_nxdomain()
+    assert handler.is_dns_error_present(error, [NXDOMAIN]) is True
+
+
+def test_is_dns_error_present_no_match(handler):
+    error = make_timeout()
+    assert handler.is_dns_error_present(error, [NXDOMAIN, SERVFAIL]) is False
+
+
+# ---------------------------------------------------------------------------
+# is_dangling_record_async
+# ---------------------------------------------------------------------------
+
+async def test_is_dangling_record_returns_false_when_record_exists(handler):
+    """A successful DNS query means the record exists — not dangling."""
+    handler.aiodns_resolver.query = AsyncMock(return_value=[dns_answer("1.2.3.4")])
+
+    result = await handler.is_dangling_record_async("example.com", "A")
+
+    assert result is False
+
+
+async def test_is_dangling_record_returns_true_for_nxdomain(handler):
+    """NXDOMAIN means the record is gone — dangling."""
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
+
+    result = await handler.is_dangling_record_async("gone.example.com", "A")
+
+    assert result is True
+
+
+async def test_is_dangling_record_returns_false_for_timeout(handler):
+    """
+    A timeout means we can't tell — we conservatively say not dangling
+    rather than risk a false positive.
+    """
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_timeout())
+
+    result = await handler.is_dangling_record_async("slow.example.com", "A")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_domain_async — happy path
+# ---------------------------------------------------------------------------
+
+async def test_resolve_domain_async_success_returns_ips(handler, domain_context):
+    """When aiodns resolves successfully we get (True, [ip, ...])."""
+    handler.aiodns_resolver.query = AsyncMock(
+        return_value=[dns_answer("1.2.3.4"), dns_answer("5.6.7.8")]
+    )
+    # Stub out takeover checks so this test stays focused on resolution
+    handler.handle_takeover_checks = AsyncMock(return_value=False)
+
+    success, ips = await handler.resolve_domain_async(domain_context)
+
+    assert success is True
+    assert "1.2.3.4" in ips
+    assert "5.6.7.8" in ips
+
+
+async def test_resolve_domain_async_exhausted_retries_returns_false(handler, domain_context):
+    """When every attempt fails the handler reports failure."""
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
+    handler.handle_domain_resolution_errors = AsyncMock(return_value=(False, []))
+
+    success, ips = await handler.resolve_domain_async(domain_context)
+
+    assert success is False
+    assert ips == []
+
+
+async def test_resolve_domain_async_retries_before_giving_up(handler, domain_context, mock_env_manager):
+    """
+    The handler should attempt the query (retries + 1) times before
+    declaring failure.  We configure 2 retries, so expect 3 total calls.
+    """
+    mock_env_manager.get_retries.return_value = 2
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
+    handler.handle_domain_resolution_errors = AsyncMock(return_value=(False, []))
+
+    await handler.resolve_domain_async(domain_context)
+
+    assert handler.aiodns_resolver.query.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# check_dangling_cname_async
+# ---------------------------------------------------------------------------
+
+async def test_check_dangling_cname_not_dangling_has_a_record(handler, domain_context):
+    """
+    If the CNAME target resolves to an A record the domain is not dangling.
+
+    We set up query() to:
+      - raise NXDOMAIN for CNAME (no CNAME record, proceed to A/AAAA/MX check)
+      - return a real answer for A (domain still alive → not dangling)
+    """
+    async def query_side_effect(domain, record_type):
+        if record_type == "CNAME":
+            raise make_nxdomain()
+        if record_type == "A":
+            return [dns_answer("1.2.3.4")]
+        raise make_nxdomain()
+
+    handler.aiodns_resolver.query = query_side_effect
+
+    result = await handler.check_dangling_cname_async(domain_context, "target.example.com")
+
+    assert result is False
+
+
+async def test_check_dangling_cname_is_dangling_no_records(handler, domain_context, mock_env_manager):
+    """
+    When A, AAAA, MX, and NS all return NXDOMAIN the domain is dangling.
+    The handler should write to the dangling file and return True.
+    """
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
+
+    result = await handler.check_dangling_cname_async(domain_context, "gone.example.com")
+
+    assert result is True
+    # Verify the result was written to the dangling output file
+    mock_env_manager.write_to_file.assert_called_once()
+    call_args = mock_env_manager.write_to_file.call_args
+    assert "/tmp/test_dangling.txt" in call_args[0]
+
+
+async def test_check_dangling_cname_timeout_is_not_dangling(handler, domain_context):
+    """
+    A timeout on A/AAAA/MX means we can't confirm the domain is gone.
+    We conservatively return False to avoid false positives.
+    """
+    async def query_side_effect(domain, record_type):
+        if record_type == "CNAME":
+            raise make_nxdomain()
+        raise make_timeout()  # all other record types time out
+
+    handler.aiodns_resolver.query = query_side_effect
+
+    result = await handler.check_dangling_cname_async(domain_context, "slow.example.com")
+
+    assert result is False

--- a/tests/test_domain_processing_context.py
+++ b/tests/test_domain_processing_context.py
@@ -1,0 +1,78 @@
+"""
+Tests for DomainProcessingContext.
+
+Introduces pytest fixtures — the `mock_env_manager` and `csp_ips` fixtures
+are defined in conftest.py and injected automatically by pytest when a test
+function lists them as parameters.
+"""
+
+import pytest
+
+from classes.domain_processing_context import DomainProcessingContext
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a fresh context for each test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ctx(mock_env_manager, csp_ips):
+    """A DomainProcessingContext wired up with fake dependencies."""
+    context = DomainProcessingContext(mock_env_manager, csp_ips)
+    context.set_domain("example.com")
+    return context
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+def test_dangling_domains_starts_empty(ctx):
+    assert ctx.dangling_domains == set()
+
+
+def test_failed_domains_starts_empty(ctx):
+    assert ctx.failed_domains == set()
+
+
+def test_domain_is_set_correctly(ctx):
+    assert ctx.get_domain() == "example.com"
+
+
+def test_csp_ip_addresses_stored(ctx, csp_ips):
+    assert ctx.get_csp_ip_addresses() is csp_ips
+
+
+# ---------------------------------------------------------------------------
+# Dangling domain tracking
+# ---------------------------------------------------------------------------
+
+def test_add_dangling_domain(ctx):
+    ctx.add_dangling_domain_to_domains("cname-target.example.com")
+    assert "cname-target.example.com" in ctx.dangling_domains
+
+
+def test_add_multiple_dangling_domains(ctx):
+    ctx.add_dangling_domain_to_domains("a.example.com")
+    ctx.add_dangling_domain_to_domains("b.example.com")
+    assert ctx.dangling_domains == {"a.example.com", "b.example.com"}
+
+
+def test_add_duplicate_dangling_domain_is_idempotent(ctx):
+    """Sets deduplicate automatically — adding the same domain twice is fine."""
+    ctx.add_dangling_domain_to_domains("dup.example.com")
+    ctx.add_dangling_domain_to_domains("dup.example.com")
+    assert len(ctx.dangling_domains) == 1
+
+
+# ---------------------------------------------------------------------------
+# Resolver creation
+# ---------------------------------------------------------------------------
+
+def test_resolver_is_none_before_create(ctx):
+    assert ctx.get_resolver() is None
+
+
+def test_create_resolver_produces_resolver(ctx):
+    ctx.create_resolver()
+    assert ctx.get_resolver() is not None


### PR DESCRIPTION
## Summary

This is the complete async redesign of DNSResolver, replacing the old `threading.Thread` model with `asyncio` + `aiodns` for significantly better performance on large domain lists.

- Replaces `threading.Thread` pool with `asyncio.gather` + `asyncio.Semaphore`
- Introduces `DNSHandler` — all DNS logic in one place, async throughout
- Introduces `CSPIPAddresses` — clean value object for cloud IP ranges
- Introduces `EvidenceCollector` — async subprocess evidence capture
- `DomainProcessingContext` stripped to domain-specific state only; config delegated to `EnvironmentManager`
- `create_domain_context` factory eliminates 15-setter construction ceremony
- Retry loop restored and working correctly with async gather
- Dangling domains aggregated across all coroutines and logged at completion
- Updated README with correct CLI flags, output file reference, and architecture diagram
- 24 passing tests covering `CSPIPAddresses`, `DomainProcessingContext`, and `DNSHandler`

## Fixes included

- #24 retry loop missing in async redesign
- #25 blocking dnspython calls inside async functions
- #26 DNSHandler instantiated per-domain instead of shared
- #27 no concurrency cap on asyncio.gather
- #28 NS takeover check querying wrong domain
- #29 dangling domain results not aggregated back from coroutines

## Breaking changes

- Requires `pip install -r requirements.txt` (adds `aiodns`, `aiofiles`, `pytest`, `pytest-asyncio`)
- `DomainProcessingContext` constructor now takes `csp_ip_addresses` as second argument
- `--max-threads` now caps async coroutine concurrency, not thread count
- Entry point is now `asyncio.run(main_async())` — not directly callable as a sync function

## Test plan

- [ ] `source .venv/bin/activate && pytest -v` — all 24 tests pass
- [ ] Run against a real domain list and verify output files are populated correctly
- [ ] Run with `--retries 2` against a list with unreliable domains — confirm retry behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)