### PR TITLE
fix: pin urllib3>=2.6.3 to resolve all 7 Dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dnspython>=2.2.1
 requests>=2.28.1
+urllib3>=2.6.3
 tqdm>=4.64.1
 argparse~=1.4.0
 selenium~=4.22.0


### PR DESCRIPTION
## Summary

Adds an explicit `urllib3>=2.6.3` pin to `requirements.txt`.

`urllib3` is a transitive dependency of `requests` and was not previously pinned, leaving the version uncontrolled and vulnerable.

## Alerts resolved

| Alert | Severity | Fixed in |
|-------|----------|----------|
| Cookie header leaked on cross-origin redirects | High | 1.26.17 |
| Request body not stripped on 303 redirect | Moderate | 1.26.18 |
| Proxy-Authorization not stripped on cross-origin redirect | Moderate | 1.26.19 |
| Redirects not disabled when retries disabled on PoolManager | Moderate | 2.5.0 |
| Unbounded decompression chain links | High | 2.6.0 |
| Highly compressed data mishandled in streaming API | High | 2.6.0 |
| Decompression-bomb safeguard bypass via redirects | High | 2.6.3 |

## Test plan
- [x] 24 existing tests pass with urllib3 2.7.0 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)