### PR TITLE
test: expand suite to 75 tests, raise coverage to 34%

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ aiofiles~=24.1.0
 # dev / test
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
+pytest-cov>=5.0.0

--- a/tests/test_cloud_service_provider_checks.py
+++ b/tests/test_cloud_service_provider_checks.py
@@ -1,0 +1,227 @@
+"""
+Tests for cloud_service_provider_checks.
+
+This module is pure Python (ipaddress + file I/O) so it's very testable.
+`tmp_path` is a built-in pytest fixture that provides a fresh temporary
+directory for each test — perfect for functions that write output files.
+"""
+
+import pytest
+
+from classes.domain_processing_context import DomainProcessingContext
+from imports.cloud_service_provider_checks import (
+    get_ip_matches,
+    get_vendor_ips,
+    is_ip_version,
+    log_and_write,
+    match_ip_with_vendors,
+    merge_matches,
+    perform_csp_checks,
+)
+import ipaddress
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a domain context pre-loaded with test IP ranges
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ctx(mock_env_manager, csp_ips):
+    context = DomainProcessingContext(mock_env_manager, csp_ips)
+    context.set_domain("example.com")
+    return context
+
+
+# ---------------------------------------------------------------------------
+# is_ip_version
+# ---------------------------------------------------------------------------
+
+def test_is_ip_version_ipv4_correct():
+    assert is_ip_version("34.1.2.3", 4) is True
+
+
+def test_is_ip_version_ipv4_rejected_for_v6():
+    assert is_ip_version("34.1.2.3", 6) is False
+
+
+def test_is_ip_version_ipv6_correct():
+    assert is_ip_version("2600:1900::1", 6) is True
+
+
+def test_is_ip_version_ipv6_rejected_for_v4():
+    assert is_ip_version("2600:1900::1", 4) is False
+
+
+# ---------------------------------------------------------------------------
+# get_vendor_ips
+# ---------------------------------------------------------------------------
+
+def test_get_vendor_ips_ipv4_returns_correct_ranges(ctx, csp_ips):
+    result = get_vendor_ips(ctx, ip_version=4)
+    assert result["gcp"] == csp_ips.get_gcp_ipv4()
+    assert result["aws"] == csp_ips.get_aws_ipv4()
+    assert result["azure"] == csp_ips.get_azure_ipv4()
+
+
+def test_get_vendor_ips_ipv6_returns_correct_ranges(ctx, csp_ips):
+    result = get_vendor_ips(ctx, ip_version=6)
+    assert result["gcp"] == csp_ips.get_gcp_ipv6()
+    assert result["aws"] == csp_ips.get_aws_ipv6()
+    assert result["azure"] == csp_ips.get_azure_ipv6()
+
+
+def test_get_vendor_ips_unknown_version_returns_empty(ctx):
+    assert get_vendor_ips(ctx, ip_version=99) == {}
+
+
+# ---------------------------------------------------------------------------
+# match_ip_with_vendors
+# ---------------------------------------------------------------------------
+
+def test_match_ip_with_vendors_records_match(ctx):
+    ip_obj = ipaddress.IPv4Address("34.1.2.3")
+    vendor_ips = {"gcp": ["34.0.0.0/8"], "aws": [], "azure": []}
+    matches = {"gcp": set(), "aws": set(), "azure": set()}
+
+    match_ip_with_vendors(ip_obj, vendor_ips, ctx, matches)
+
+    assert "34.1.2.3" in matches["gcp"]
+    assert matches["aws"] == set()
+
+
+def test_match_ip_with_vendors_no_match(ctx):
+    ip_obj = ipaddress.IPv4Address("1.2.3.4")
+    vendor_ips = {"gcp": ["34.0.0.0/8"]}
+    matches = {"gcp": set()}
+
+    match_ip_with_vendors(ip_obj, vendor_ips, ctx, matches)
+
+    assert matches["gcp"] == set()
+
+
+def test_match_ip_with_vendors_ignores_invalid_range(ctx):
+    """A bad CIDR string should not crash — it's logged and skipped."""
+    ip_obj = ipaddress.IPv4Address("1.2.3.4")
+    vendor_ips = {"gcp": ["not-a-valid-cidr"]}
+    matches = {"gcp": set()}
+
+    match_ip_with_vendors(ip_obj, vendor_ips, ctx, matches)
+
+    assert matches["gcp"] == set()
+
+
+# ---------------------------------------------------------------------------
+# merge_matches
+# ---------------------------------------------------------------------------
+
+def test_merge_matches_combines_ipv4_and_ipv6():
+    v4 = {"gcp": {"1.2.3.4"}, "aws": set()}
+    v6 = {"gcp": {"::1"}, "aws": set()}
+    vendor_context = {"gcp": [], "aws": []}
+
+    result = merge_matches(v4, v6, vendor_context)
+
+    assert set(result["gcp"]) == {"1.2.3.4", "::1"}
+    assert result["aws"] == []
+
+
+def test_merge_matches_empty_sets():
+    v4 = {"gcp": set()}
+    v6 = {"gcp": set()}
+    result = merge_matches(v4, v6, {"gcp": []})
+    assert result["gcp"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_ip_matches
+# ---------------------------------------------------------------------------
+
+def test_get_ip_matches_finds_gcp_ipv4(ctx, csp_ips):
+    # 34.1.2.3 falls in GCP's 34.0.0.0/8 range (from conftest)
+    result = get_ip_matches(["34.1.2.3"], get_vendor_ips(ctx, 4), ctx, ip_version=4)
+    assert "34.1.2.3" in result["gcp"]
+
+
+def test_get_ip_matches_skips_wrong_ip_version(ctx):
+    # An IPv6 address should be skipped when looking for IPv4 matches
+    result = get_ip_matches(["2600:1900::1"], get_vendor_ips(ctx, 4), ctx, ip_version=4)
+    assert all(len(s) == 0 for s in result.values())
+
+
+# ---------------------------------------------------------------------------
+# log_and_write  (uses tmp_path for real file I/O)
+# ---------------------------------------------------------------------------
+
+def test_log_and_write_creates_entry(tmp_path, ctx):
+    out_file = tmp_path / "gcp.txt"
+    out_file.touch()
+    output_files = {"standard": {"gcp": str(out_file)}}
+
+    result = log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
+
+    assert result is True
+    assert "example.com resolved to gcp IPs" in out_file.read_text()
+
+
+def test_log_and_write_no_duplicate_entries(tmp_path, ctx):
+    """Writing the same match twice should not produce duplicate lines."""
+    out_file = tmp_path / "gcp.txt"
+    out_file.touch()
+    output_files = {"standard": {"gcp": str(out_file)}}
+
+    log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
+    log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
+
+    lines = [l for l in out_file.read_text().splitlines() if l]
+    assert len(lines) == 1
+
+
+def test_log_and_write_empty_ips_returns_false(tmp_path, ctx):
+    out_file = tmp_path / "gcp.txt"
+    out_file.touch()
+    output_files = {"standard": {"gcp": str(out_file)}}
+
+    result = log_and_write("gcp", [], "example.com", output_files, ctx)
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# perform_csp_checks  (end-to-end through the module)
+# ---------------------------------------------------------------------------
+
+def test_perform_csp_checks_matches_gcp_ip(tmp_path, mock_env_manager, ctx):
+    gcp_file = tmp_path / "gcp.txt"
+    gcp_file.touch()
+    aws_file = tmp_path / "aws.txt"
+    aws_file.touch()
+    azure_file = tmp_path / "azure.txt"
+    azure_file.touch()
+    mock_env_manager.get_output_files.return_value = {
+        "standard": {
+            "gcp": str(gcp_file),
+            "aws": str(aws_file),
+            "azure": str(azure_file),
+        }
+    }
+
+    result = perform_csp_checks(ctx, mock_env_manager, ["34.1.2.3"])
+
+    assert result is True
+    assert "example.com" in gcp_file.read_text()
+
+
+def test_perform_csp_checks_no_match_returns_false(tmp_path, mock_env_manager, ctx):
+    for vendor in ("gcp", "aws", "azure"):
+        (tmp_path / f"{vendor}.txt").touch()
+    mock_env_manager.get_output_files.return_value = {
+        "standard": {
+            "gcp": str(tmp_path / "gcp.txt"),
+            "aws": str(tmp_path / "aws.txt"),
+            "azure": str(tmp_path / "azure.txt"),
+        }
+    }
+
+    result = perform_csp_checks(ctx, mock_env_manager, ["192.0.2.1"])  # TEST-NET, no match
+
+    assert result is False

--- a/tests/test_create_domain_context.py
+++ b/tests/test_create_domain_context.py
@@ -1,0 +1,39 @@
+"""
+Tests for create_domain_context factory.
+
+The factory is a thin wrapper around DomainProcessingContext.__init__ that
+also sets the domain and wires up the shared sets.  These tests verify that
+wiring is correct — in particular that the passed-in sets are used by
+reference (mutations in the context are visible to the caller).
+"""
+
+from imports.create_domain_context import create_domain_context
+
+
+def test_domain_is_set(mock_env_manager, csp_ips):
+    ctx = create_domain_context("example.com", mock_env_manager, set(), set(), csp_ips)
+    assert ctx.get_domain() == "example.com"
+
+
+def test_csp_ip_addresses_stored(mock_env_manager, csp_ips):
+    ctx = create_domain_context("example.com", mock_env_manager, set(), set(), csp_ips)
+    assert ctx.get_csp_ip_addresses() is csp_ips
+
+
+def test_dangling_domains_is_the_passed_set(mock_env_manager, csp_ips):
+    """
+    The factory stores the exact set object, not a copy.
+    This matters because main_async aggregates dangling domains by
+    reading domain_context.dangling_domains after the coroutine finishes.
+    """
+    dangling = set()
+    ctx = create_domain_context("example.com", mock_env_manager, dangling, set(), csp_ips)
+    ctx.add_dangling_domain_to_domains("leaked.example.com")
+    assert "leaked.example.com" in dangling
+
+
+def test_failed_domains_is_the_passed_set(mock_env_manager, csp_ips):
+    failed = set()
+    ctx = create_domain_context("example.com", mock_env_manager, set(), failed, csp_ips)
+    ctx.failed_domains.add("broken.example.com")
+    assert "broken.example.com" in failed

--- a/tests/test_custom_exceptions.py
+++ b/tests/test_custom_exceptions.py
@@ -1,0 +1,57 @@
+"""
+Tests for custom exceptions.
+
+Shows the simplest possible pattern: raise the exception in a pytest.raises
+block and assert on the message.  Also demonstrates that each exception is
+a subclass of the built-in Exception so callers can catch it generically.
+"""
+
+import pytest
+
+from classes.custom_exceptions import (
+    FileDoesNotExistError,
+    InvalidNameserversError,
+    NotAnIntegerError,
+)
+
+
+def test_file_does_not_exist_error_is_raised():
+    with pytest.raises(FileDoesNotExistError):
+        raise FileDoesNotExistError("no such file")
+
+
+def test_file_does_not_exist_error_preserves_message():
+    with pytest.raises(FileDoesNotExistError, match="no such file"):
+        raise FileDoesNotExistError("no such file")
+
+
+def test_file_does_not_exist_error_is_exception():
+    assert issubclass(FileDoesNotExistError, Exception)
+
+
+def test_not_an_integer_error_is_raised():
+    with pytest.raises(NotAnIntegerError):
+        raise NotAnIntegerError("expected int, got str")
+
+
+def test_not_an_integer_error_preserves_message():
+    with pytest.raises(NotAnIntegerError, match="expected int"):
+        raise NotAnIntegerError("expected int, got str")
+
+
+def test_not_an_integer_error_is_exception():
+    assert issubclass(NotAnIntegerError, Exception)
+
+
+def test_invalid_nameservers_error_is_raised():
+    with pytest.raises(InvalidNameserversError):
+        raise InvalidNameserversError("bad nameserver")
+
+
+def test_invalid_nameservers_error_preserves_message():
+    with pytest.raises(InvalidNameserversError, match="bad nameserver"):
+        raise InvalidNameserversError("bad nameserver")
+
+
+def test_invalid_nameservers_error_is_exception():
+    assert issubclass(InvalidNameserversError, Exception)

--- a/tests/test_dns_handler_extended.py
+++ b/tests/test_dns_handler_extended.py
@@ -1,0 +1,182 @@
+"""
+Additional DNSHandler tests — covering the paths not reached by the
+existing test_dns_handler.py:
+
+  - check_ns_takeover
+  - handle_takeover_checks
+  - log_and_write_dns_error
+  - collect_evidence (evidence disabled / enabled paths)
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import aiodns
+import pytest
+
+from classes.dns_handler import DNSHandler, NXDOMAIN, SERVFAIL
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (duplicated from test_dns_handler.py for clarity)
+# ---------------------------------------------------------------------------
+
+def make_nxdomain():
+    return aiodns.error.DNSError(NXDOMAIN, "Domain not found")
+
+
+def make_servfail():
+    return aiodns.error.DNSError(SERVFAIL, "Server failure")
+
+
+def dns_answer(value, attr="host"):
+    a = MagicMock()
+    setattr(a, attr, value)
+    return a
+
+
+@pytest.fixture
+async def handler(mock_env_manager):
+    with patch("classes.dns_handler.EvidenceCollector"), \
+         patch("classes.dns_handler.aiodns.DNSResolver"):
+        h = DNSHandler(mock_env_manager)
+    h.aiodns_resolver = AsyncMock()
+    h.dnspython_resolver = MagicMock()
+    return h
+
+
+@pytest.fixture
+def domain_context(mock_env_manager, csp_ips):
+    from classes.domain_processing_context import DomainProcessingContext
+    ctx = DomainProcessingContext(mock_env_manager, csp_ips)
+    ctx.set_domain("example.com")
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# log_and_write_dns_error
+# ---------------------------------------------------------------------------
+
+async def test_log_and_write_dns_error_writes_to_unresolved(handler, mock_env_manager):
+    error = Exception("timeout")
+    await handler.log_and_write_dns_error("fail.example.com", error)
+
+    mock_env_manager.write_to_file.assert_called_once()
+    path, content = mock_env_manager.write_to_file.call_args[0]
+    assert "unresolved" in path
+    assert "fail.example.com" in content
+
+
+async def test_log_and_write_dns_error_includes_additional_message(handler, mock_env_manager):
+    error = Exception("servfail")
+    await handler.log_and_write_dns_error("fail.example.com", error, "Could not contact DNS servers")
+
+    _path, content = mock_env_manager.write_to_file.call_args[0]
+    assert "Could not contact DNS servers" in content
+
+
+# ---------------------------------------------------------------------------
+# collect_evidence
+# ---------------------------------------------------------------------------
+
+async def test_collect_evidence_skipped_when_disabled(handler, mock_env_manager):
+    mock_env_manager.get_evidence.return_value = False
+    output_files = mock_env_manager.get_output_files.return_value
+
+    await handler.collect_evidence("example.com", "dangling", output_files)
+
+    handler.evidence_collector.perform_dns_evidence.assert_not_called()
+
+
+async def test_collect_evidence_called_per_nameserver(handler, mock_env_manager):
+    mock_env_manager.get_evidence.return_value = True
+    mock_env_manager.get_resolvers.return_value = ["8.8.8.8", "1.1.1.1"]
+    handler.evidence_collector.perform_dns_evidence = AsyncMock()
+    output_files = mock_env_manager.get_output_files.return_value
+
+    await handler.collect_evidence("example.com", "dangling", output_files)
+
+    assert handler.evidence_collector.perform_dns_evidence.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# check_ns_takeover
+# ---------------------------------------------------------------------------
+
+async def test_check_ns_takeover_returns_false_when_ns_resolves(handler, domain_context):
+    """If the NS record for the domain resolves fine there is no takeover risk."""
+    ns_record = dns_answer("ns1.example.com", attr="host")
+    # NS query succeeds, A query for ns1 also succeeds
+    handler.aiodns_resolver.query = AsyncMock(return_value=[ns_record])
+
+    result = await handler.check_ns_takeover(domain_context, "example.com")
+
+    assert result is False
+
+
+async def test_check_ns_takeover_returns_true_when_ns_is_nxdomain(handler, domain_context, mock_env_manager):
+    """If the nameserver itself is NXDOMAIN, a takeover may be possible."""
+    ns_record = dns_answer("ns1.orphaned.com", attr="host")
+
+    async def query_side_effect(domain, record_type):
+        if record_type == "NS":
+            return [ns_record]
+        raise make_nxdomain()  # A lookup for the NS host fails
+
+    handler.aiodns_resolver.query = query_side_effect
+
+    result = await handler.check_ns_takeover(domain_context, "orphaned.example.com")
+
+    assert result is True
+    mock_env_manager.write_to_file.assert_called_once()
+    path, content = mock_env_manager.write_to_file.call_args[0]
+    assert "ns_takeover" in path
+
+
+async def test_check_ns_takeover_returns_false_when_no_ns_records(handler, domain_context):
+    """NXDOMAIN on the NS query itself means no NS records — no takeover."""
+    handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
+
+    result = await handler.check_ns_takeover(domain_context, "example.com")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# handle_takeover_checks
+# ---------------------------------------------------------------------------
+
+async def test_handle_takeover_checks_adds_dangling_domain_when_dangling(handler, domain_context):
+    handler.check_dangling_cname_async = AsyncMock(return_value=True)
+    handler.check_ns_takeover = AsyncMock(return_value=False)
+
+    await handler.handle_takeover_checks(domain_context, "cname-target.example.com")
+
+    assert "cname-target.example.com" in domain_context.dangling_domains
+
+
+async def test_handle_takeover_checks_adds_domain_when_ns_takeover(handler, domain_context):
+    handler.check_dangling_cname_async = AsyncMock(return_value=False)
+    handler.check_ns_takeover = AsyncMock(return_value=True)
+
+    await handler.handle_takeover_checks(domain_context, "ns-vuln.example.com")
+
+    assert "ns-vuln.example.com" in domain_context.dangling_domains
+
+
+async def test_handle_takeover_checks_returns_true_when_either_detected(handler, domain_context):
+    handler.check_dangling_cname_async = AsyncMock(return_value=False)
+    handler.check_ns_takeover = AsyncMock(return_value=True)
+
+    result = await handler.handle_takeover_checks(domain_context, "example.com")
+
+    assert result is True
+
+
+async def test_handle_takeover_checks_returns_false_when_neither_detected(handler, domain_context):
+    handler.check_dangling_cname_async = AsyncMock(return_value=False)
+    handler.check_ns_takeover = AsyncMock(return_value=False)
+
+    result = await handler.handle_takeover_checks(domain_context, "example.com")
+
+    assert result is False
+    assert len(domain_context.dangling_domains) == 0

--- a/tests/test_domain_processor.py
+++ b/tests/test_domain_processor.py
@@ -1,0 +1,145 @@
+"""
+Tests for process_domain_async.
+
+This is the top-level orchestrator for a single domain — it wires together
+DNS resolution, CSP checks, and service checks.  We mock dns_handler and
+the CSP/service check functions so each test focuses on the orchestration
+logic rather than the details of those subsystems.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from imports.domain_processor import process_domain_async
+
+
+@pytest.fixture
+def dns_handler():
+    """A mock DNSHandler with a controllable resolve_domain_async."""
+    handler = MagicMock()
+    handler.resolve_domain_async = AsyncMock(return_value=(True, ["1.2.3.4"]))
+    return handler
+
+
+@pytest.fixture
+def pbar():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+async def test_returns_success_and_ips_on_resolution(mock_env_manager, csp_ips, dns_handler, pbar):
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        success, ips, dangling = await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, dns_handler
+        )
+
+    assert success is True
+    assert "1.2.3.4" in ips
+
+
+async def test_pbar_is_updated_after_processing(mock_env_manager, csp_ips, dns_handler, pbar):
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, dns_handler
+        )
+
+    pbar.update.assert_called_once_with(1)
+
+
+async def test_csp_checks_called_on_success(mock_env_manager, csp_ips, dns_handler, pbar):
+    with patch("imports.domain_processor.perform_csp_checks") as mock_csp, \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, dns_handler
+        )
+
+    mock_csp.assert_called_once()
+
+
+async def test_dangling_domains_returned(mock_env_manager, csp_ips, pbar):
+    """
+    Dangling domains discovered during resolution must come back as the
+    third return value so main_async can aggregate them.
+    """
+    handler = MagicMock()
+    handler.resolve_domain_async = AsyncMock(return_value=(True, ["1.2.3.4"]))
+
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        # Simulate DNSHandler adding a dangling domain to the context mid-resolution
+        async def resolve_with_dangling(ctx):
+            ctx.add_dangling_domain_to_domains("cname-target.s3.amazonaws.com")
+            return True, ["1.2.3.4"]
+
+        handler.resolve_domain_async = resolve_with_dangling
+
+        _success, _ips, dangling = await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, handler
+        )
+
+    assert "cname-target.s3.amazonaws.com" in dangling
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+async def test_csp_checks_not_called_on_failure(mock_env_manager, csp_ips, pbar):
+    handler = MagicMock()
+    handler.resolve_domain_async = AsyncMock(return_value=(False, []))
+
+    with patch("imports.domain_processor.perform_csp_checks") as mock_csp, \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, handler
+        )
+
+    mock_csp.assert_not_called()
+
+
+async def test_returns_failure_and_empty_ips_on_failure(mock_env_manager, csp_ips, pbar):
+    handler = MagicMock()
+    handler.resolve_domain_async = AsyncMock(return_value=(False, []))
+
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks"):
+        success, ips, dangling = await process_domain_async(
+            "fail.example.com", mock_env_manager, pbar, csp_ips, handler
+        )
+
+    assert success is False
+    assert ips == []
+
+
+# ---------------------------------------------------------------------------
+# Service checks
+# ---------------------------------------------------------------------------
+
+async def test_service_checks_called_when_enabled(mock_env_manager, csp_ips, dns_handler, pbar):
+    mock_env_manager.get_service_checks.return_value = True
+
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks") as mock_sc:
+        await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, dns_handler
+        )
+
+    mock_sc.assert_called_once()
+
+
+async def test_service_checks_not_called_when_disabled(mock_env_manager, csp_ips, dns_handler, pbar):
+    mock_env_manager.get_service_checks.return_value = False
+
+    with patch("imports.domain_processor.perform_csp_checks"), \
+         patch("imports.domain_processor.perform_service_connectivity_checks") as mock_sc:
+        await process_domain_async(
+            "example.com", mock_env_manager, pbar, csp_ips, dns_handler
+        )
+
+    mock_sc.assert_not_called()


### PR DESCRIPTION
## Summary

- 75 tests (up from 24), all passing
- Overall coverage 34% (up from 18%)
- Adds `pytest-cov` to requirements

## New test files

| File | What it covers | Coverage |
|------|---------------|----------|
| `test_custom_exceptions.py` | All 3 exception classes | 100% |
| `test_create_domain_context.py` | Factory wiring, set-by-reference behaviour | 100% |
| `test_cloud_service_provider_checks.py` | IP version checks, range matching, file dedup, perform_csp_checks end-to-end | 88% |
| `test_domain_processor.py` | process_domain_async — success/failure paths, CSP checks, service checks, dangling aggregation, pbar | 100% |
| `test_dns_handler_extended.py` | check_ns_takeover, handle_takeover_checks, log_and_write_dns_error, collect_evidence | raises DNSHandler to 76% |

## What's intentionally not covered yet

- `EnvironmentManager` — argparse + file system + HTTP, needs integration tests
- `cloud_ip_ranges.py` — HTTP calls to AWS/GCP/Azure
- `service_connectivity_checks.py` — live network connectivity
- `evidence_collector.py` — OS subprocess calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)