### PR TITLE
v1.2.0: AWS Lambda entrypoint with S3 I/O (#37)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# DNSResolver Lambda container image
+#
+# Architecture: arm64 (Graviton) — ~20% cheaper than x86_64 for equivalent workloads.
+# Change to public.ecr.aws/lambda/python:3.12 for x86_64.
+#
+# pycares bundles a native C extension (libcares). Using a container image
+# avoids the manylinux wheel compatibility issues that arise with Lambda layers.
+#
+# Build:
+#   docker build --platform linux/arm64 -t dnsresolver-lambda .
+#
+# Push to ECR and deploy:
+#   aws ecr get-login-password | docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
+#   docker tag dnsresolver-lambda <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+#   docker push <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+
+FROM public.ecr.aws/lambda/python:3.12-arm64
+
+COPY requirements-lambda.txt ./
+RUN pip install --no-cache-dir -r requirements-lambda.txt
+
+COPY . .
+
+CMD ["lambda_handler.handler"]

--- a/README.md
+++ b/README.md
@@ -83,15 +83,79 @@ Each run creates a timestamped subdirectory under the output directory containin
 | `environment_results_*.json` | Run metadata (command, external IP, Docker status) |
 | `evidence/dns/` | dig or nslookup output per flagged domain (when `--evidence` is set) |
 
+## AWS Lambda deployment
+
+DNSResolver can run as a Lambda function triggered by an S3 PutObject event. Upload a domains file to the input bucket to start a run; results are written back to S3 when it completes.
+
+### Design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Packaging | Container image | `pycares` bundles a native C extension — container images avoid the manylinux wheel compatibility issues that affect Lambda layers |
+| Architecture | arm64 (Graviton) | ~20% cheaper than x86_64 for equivalent workloads; change `FROM` line in Dockerfile for x86_64 |
+| Runtime | Python 3.12 | Latest Lambda-supported version |
+| Logging | stdout only | Lambda captures stdout to CloudWatch automatically; no log file is written |
+| Evidence collection | Disabled | `dig` and `nslookup` are not available in the Lambda runtime |
+| Intermediate storage | `/tmp` | Lambda provides up to 10 GB of ephemeral storage; results are uploaded to S3 at the end of the run |
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OUTPUT_BUCKET` | input bucket | S3 bucket for results |
+| `OUTPUT_PREFIX` | `results/` | S3 key prefix for results |
+| `NAMESERVERS` | system resolvers | Comma-separated custom resolvers, e.g. `8.8.8.8,1.1.1.1` |
+| `MAX_THREADS` | `50` | Concurrent domain tasks |
+| `TIMEOUT` | from `config.json` | DNS query timeout in seconds |
+| `RETRIES` | from `config.json` | Retry attempts for failed domains |
+| `VERBOSE` | `false` | Set to `true` for verbose CloudWatch logging |
+
+### IAM permissions
+
+The Lambda execution role needs:
+- `s3:GetObject` on the input bucket
+- `s3:PutObject` on the output bucket
+
+### Build and deploy
+
+```bash
+# Build (cross-compile for arm64 from an x86 machine if needed)
+docker build --platform linux/arm64 -t dnsresolver-lambda .
+
+# Push to ECR
+aws ecr get-login-password --region <region> \
+  | docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
+docker tag dnsresolver-lambda <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+docker push <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+```
+
+### Trigger configuration
+
+Configure an S3 event notification on the input bucket for `s3:ObjectCreated:*` events, filtered to the prefix where you drop domain files (e.g. `domains/`). The Lambda handler reads the bucket and key from the event record automatically.
+
+### Pipeline integration
+
+```
+EventBridge (daily cron)
+    → ECS Fargate task (subfinder/amass enumeration)
+        → S3: domains/domains.txt          ← triggers Lambda
+            → Lambda (DNSResolver)
+                → S3: results/<timestamp>/
+                    → downstream Lambda (claim dangling resources)
+```
+
 ## Architecture
 
 ```
-resolver.py          — asyncio entry point, retry loop, concurrency cap
-├── EnvironmentManager   — argument parsing, config, logging, output setup
-├── DNSHandler           — async DNS resolution (aiodns primary, dnspython fallback)
-│   └── EvidenceCollector — async subprocess evidence capture (dig/nslookup)
-├── DomainProcessingContext — per-domain state (domain name, resolver, CSP IPs)
-├── CSPIPAddresses       — value object holding fetched AWS/GCP/Azure IP ranges
+resolver.py              — CLI entry point → run(env_manager)
+lambda_handler.py        — Lambda entry point → run(env_manager)
+    └── run()            — shared async pipeline (retry loop, concurrency cap)
+├── EnvironmentManager       — CLI: argparse, config, logging, local file I/O
+├── LambdaEnvironmentManager — Lambda: env vars, stdout logging, /tmp file I/O
+├── DNSHandler               — async DNS resolution (aiodns primary, dnspython fallback)
+│   └── EvidenceCollector     — async subprocess evidence capture (dig/nslookup)
+├── DomainProcessingContext   — per-domain state (domain name, resolver, CSP IPs)
+├── CSPIPAddresses            — value object holding fetched AWS/GCP/Azure IP ranges
 └── domain_processor.py  — orchestrates DNS → CSP checks per domain
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,17 +116,136 @@ The Lambda execution role needs:
 - `s3:GetObject` on the input bucket
 - `s3:PutObject` on the output bucket
 
-### Build and deploy
+### Step-by-step setup
 
+Replace `<account>`, `<region>`, `<input-bucket>`, and `<output-bucket>` throughout.
+
+**1. Create the ECR repository**
 ```bash
-# Build (cross-compile for arm64 from an x86 machine if needed)
+aws ecr create-repository \
+  --repository-name dnsresolver-lambda \
+  --region <region>
+```
+
+**2. Build and push the container image**
+```bash
+# Build for arm64 (cross-compile if you're on an x86 machine)
 docker build --platform linux/arm64 -t dnsresolver-lambda .
 
-# Push to ECR
+# Authenticate and push
 aws ecr get-login-password --region <region> \
   | docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
-docker tag dnsresolver-lambda <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
-docker push <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+
+docker tag dnsresolver-lambda \
+  <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+
+docker push \
+  <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
+```
+
+**3. Create the IAM execution role**
+```bash
+# Create role
+aws iam create-role \
+  --role-name dnsresolver-lambda-role \
+  --assume-role-policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {"Service": "lambda.amazonaws.com"},
+      "Action": "sts:AssumeRole"
+    }]
+  }'
+
+# Attach basic Lambda execution policy (CloudWatch Logs)
+aws iam attach-role-policy \
+  --role-name dnsresolver-lambda-role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+# Allow S3 access (adjust bucket ARNs as needed)
+aws iam put-role-policy \
+  --role-name dnsresolver-lambda-role \
+  --policy-name dnsresolver-s3 \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "s3:GetObject",
+        "Resource": "arn:aws:s3:::<input-bucket>/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::<output-bucket>/*"
+      }
+    ]
+  }'
+```
+
+**4. Create the Lambda function**
+```bash
+aws lambda create-function \
+  --function-name dnsresolver \
+  --package-type Image \
+  --code ImageUri=<account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest \
+  --role arn:aws:iam::<account>:role/dnsresolver-lambda-role \
+  --architectures arm64 \
+  --memory-size 512 \
+  --timeout 900 \
+  --environment 'Variables={
+    OUTPUT_BUCKET=<output-bucket>,
+    OUTPUT_PREFIX=results,
+    NAMESERVERS=8.8.8.8,1.1.1.1,
+    MAX_THREADS=50,
+    RETRIES=2
+  }'
+```
+
+> **Memory and timeout:** 512 MB is sufficient for most domain lists up to a few thousand entries. Increase memory for larger lists. Timeout is set to 900 seconds (Lambda maximum).
+
+**5. Add the S3 trigger**
+
+First, grant S3 permission to invoke the function:
+```bash
+aws lambda add-permission \
+  --function-name dnsresolver \
+  --statement-id s3-invoke \
+  --action lambda:InvokeFunction \
+  --principal s3.amazonaws.com \
+  --source-arn arn:aws:s3:::<input-bucket>
+```
+
+Then configure the bucket notification (replace `<input-bucket>`):
+```bash
+aws s3api put-bucket-notification-configuration \
+  --bucket <input-bucket> \
+  --notification-configuration '{
+    "LambdaFunctionConfigurations": [{
+      "LambdaFunctionArn": "arn:aws:lambda:<region>:<account>:function:dnsresolver",
+      "Events": ["s3:ObjectCreated:*"],
+      "Filter": {
+        "Key": {"FilterRules": [{"Name": "prefix", "Value": "domains/"}]}
+      }
+    }]
+  }'
+```
+
+Any file uploaded to `s3://<input-bucket>/domains/` will now trigger a run automatically.
+
+**6. Run a scan**
+```bash
+aws s3 cp domains.txt s3://<input-bucket>/domains/domains.txt
+# Results appear in s3://<output-bucket>/results/<timestamp>/ when complete
+```
+
+**7. Updating the function after a code change**
+```bash
+docker build --platform linux/arm64 -t dnsresolver-lambda . && \
+docker push <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest && \
+aws lambda update-function-code \
+  --function-name dnsresolver \
+  --image-uri <account>.dkr.ecr.<region>.amazonaws.com/dnsresolver-lambda:latest
 ```
 
 ### Trigger configuration
@@ -214,10 +333,10 @@ Once related root domains are identified, enumerate subdomains for each and comb
 
 ## Roadmap
 
-| Issue | Description |
-|-------|-------------|
-| [#36](https://github.com/incendiary/DNSResolver/issues/36) | **Progress bar stability** — route log output through `tqdm.write()` so the progress bar stays locked to the bottom of the terminal during verbose runs |
-| [#37](https://github.com/incendiary/DNSResolver/issues/37) | **AWS Lambda / S3 support** — abstract the I/O layer and add a `lambda_handler.py` entrypoint so DNSResolver can run inside a Lambda pipeline (domains in from S3, results out to S3) without duplicating any resolution logic |
+| Issue | Status | Description |
+|-------|--------|-------------|
+| [#36](https://github.com/incendiary/DNSResolver/issues/36) | ✅ v1.1.1 | Progress bar stability — log output routed through `tqdm.write()` |
+| [#37](https://github.com/incendiary/DNSResolver/issues/37) | ✅ v1.2.0 | AWS Lambda / S3 support — `lambda_handler.py` entrypoint with S3 I/O |
 
 ## Contributing
 

--- a/classes/lambda_environment_manager.py
+++ b/classes/lambda_environment_manager.py
@@ -1,0 +1,137 @@
+import json
+import logging
+import os
+from datetime import datetime
+
+from classes.environment_manager import EnvironmentManager
+
+
+class LambdaEnvironmentManager(EnvironmentManager):
+    """
+    EnvironmentManager variant for AWS Lambda.
+
+    Differences from the CLI version:
+      - Config comes from constructor parameters and environment variables,
+        not argparse / sys.argv.
+      - Logs to stdout only (CloudWatch captures Lambda stdout automatically);
+        no log file is created.
+      - Evidence collection is disabled — dig/nslookup are not available in
+        the Lambda runtime image by default.
+      - extreme mode is disabled (IP range dumps are not useful in Lambda).
+      - Output files are written to a local path (typically /tmp) and uploaded
+        to S3 by the caller after run() completes.
+    """
+
+    def __init__(
+        self,
+        domains_file,
+        output_dir,
+        config_file="config.json",
+        nameservers=None,
+        max_threads=None,
+        timeout=None,
+        retries=None,
+        verbose=False,
+    ):
+        # Initialise base attributes directly — do NOT call super().__init__()
+        # because that triggers argparse which has no meaning in Lambda.
+        self.config = {}
+        self.args = None
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.environment_info = {
+            "command_executed": "lambda",
+            "external_ip": None,
+            "run_in_docker": False,
+        }
+        self.domains = set()
+        self.patterns = None
+        self.output_files = None
+        self._config_file = config_file
+
+        self.domains_file = domains_file
+        self.output_dir = output_dir
+        self.verbose = verbose
+        self.extreme = False
+        self.nameservers = nameservers if nameservers else None
+        self.max_threads = max_threads
+        self.timeout = timeout
+        self.retries = retries
+        self.evidence = False  # dig/nslookup not available in Lambda runtime
+
+        self.logger = self._setup_lambda_logger(verbose)
+
+        self._load_config(config_file)
+        self._apply_config_defaults()
+
+        self.initialise_environment()
+        self.save_environment_info()
+        self.load_patterns()
+
+        self.logger.info("LambdaEnvironmentManager initialized.")
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+
+    def _setup_lambda_logger(self, verbose=False):
+        """Stdout-only logger — CloudWatch captures Lambda stdout automatically."""
+        logger = logging.getLogger("DNSResolver")
+        logger.setLevel(logging.INFO)
+        if logger.hasHandlers():
+            logger.handlers.clear()
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO if verbose else logging.WARNING)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+        return logger
+
+    def _load_config(self, config_file):
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                self.config = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            self.logger.warning("Could not load config file %s: %s", config_file, e)
+            self.config = {}
+
+    def _apply_config_defaults(self):
+        """Fill in any unset values from config.json."""
+        config_args = self.config.get("config", {})
+        if self.timeout is None:
+            self.timeout = config_args.get("timeout")
+        if self.retries is None:
+            self.retries = config_args.get("retries")
+        if self.max_threads is None:
+            self.max_threads = config_args.get("max_threads", 50)
+
+    def load_patterns(self):
+        """Override to handle missing config file gracefully."""
+        try:
+            with open(self._config_file, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            self.patterns = config.get("domain_categorisation", {})
+        except (IOError, json.JSONDecodeError):
+            self.patterns = {}
+
+    def get_config_file(self):
+        return self._config_file
+
+    def log_effective_configuration(self):
+        self.logger.info(
+            "Lambda configuration: domains_file=%s output_dir=%s "
+            "max_threads=%s timeout=%s retries=%s verbose=%s",
+            self.domains_file,
+            self.output_dir,
+            self.max_threads,
+            self.timeout,
+            self.retries,
+            self.verbose,
+        )
+
+    def save_environment_info(self):
+        """Write environment JSON to the local output dir (will be uploaded to S3 by caller)."""
+        env_path = self.output_files["standard"]["environment"]
+        with open(env_path, "w", encoding="utf-8") as f:
+            json.dump(self.environment_info, f, indent=4)

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -1,0 +1,92 @@
+"""
+AWS Lambda entrypoint for DNSResolver.
+
+Trigger:  S3 PutObject event — upload a plain-text domains file to the
+          input bucket to kick off a run.
+
+Environment variables:
+  OUTPUT_BUCKET   S3 bucket for results (default: same as input bucket)
+  OUTPUT_PREFIX   S3 key prefix for results (default: results/)
+  NAMESERVERS     Comma-separated resolvers, e.g. 8.8.8.8,1.1.1.1 (optional)
+  MAX_THREADS     Concurrent domain tasks (default: 50)
+  TIMEOUT         DNS query timeout in seconds (default: from config.json)
+  RETRIES         Retry attempts for failed domains (default: from config.json)
+  VERBOSE         Set to "true" for verbose CloudWatch logging (default: false)
+
+IAM permissions required:
+  s3:GetObject  on the input bucket
+  s3:PutObject  on the output bucket
+
+Deployment: container image recommended — pycares bundles a native extension
+that must match the Lambda execution environment architecture.
+See Dockerfile for the reference image definition.
+"""
+
+import asyncio
+import logging
+import os
+
+import boto3
+
+from classes.lambda_environment_manager import LambdaEnvironmentManager
+from resolver import run
+
+logger = logging.getLogger("DNSResolver")
+
+TEMP_DIR = "/tmp"
+
+
+def handler(event, context):
+    """Lambda handler — synchronous wrapper required by the Lambda runtime."""
+    asyncio.run(_main(event))
+
+
+async def _main(event):
+    record = event["Records"][0]["s3"]
+    input_bucket = record["bucket"]["name"]
+    input_key = record["object"]["key"]
+
+    output_bucket = os.environ.get("OUTPUT_BUCKET", input_bucket)
+    output_prefix = os.environ.get("OUTPUT_PREFIX", "results/").rstrip("/")
+
+    nameservers_raw = os.environ.get("NAMESERVERS", "")
+    nameservers = [n.strip() for n in nameservers_raw.split(",") if n.strip()] or None
+
+    max_threads = int(os.environ.get("MAX_THREADS", "50"))
+    timeout = int(os.environ["TIMEOUT"]) if os.environ.get("TIMEOUT") else None
+    retries = int(os.environ["RETRIES"]) if os.environ.get("RETRIES") else None
+    verbose = os.environ.get("VERBOSE", "").lower() == "true"
+
+    s3 = boto3.client("s3")
+
+    domains_path = os.path.join(TEMP_DIR, "domains.txt")
+    s3.download_file(input_bucket, input_key, domains_path)
+    logger.info("Downloaded %s/%s to %s", input_bucket, input_key, domains_path)
+
+    output_dir = os.path.join(TEMP_DIR, "dnsresolver_output")
+
+    env_manager = LambdaEnvironmentManager(
+        domains_file=domains_path,
+        output_dir=output_dir,
+        nameservers=nameservers,
+        max_threads=max_threads,
+        timeout=timeout,
+        retries=retries,
+        verbose=verbose,
+    )
+
+    await run(env_manager)
+
+    _upload_results(s3, env_manager.get_output_dir(), output_bucket, output_prefix)
+    logger.info("Results uploaded to s3://%s/%s/", output_bucket, output_prefix)
+
+
+def _upload_results(s3_client, local_dir, bucket, prefix):
+    """Walk local_dir and upload every file to S3 under prefix."""
+    for root, _dirs, files in os.walk(local_dir):
+        for filename in files:
+            local_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(local_path, local_dir)
+            s3_key = f"{prefix}/{relative_path}"
+            s3_client.upload_file(local_path, bucket, s3_key)
+            logger.info("Uploaded %s → s3://%s/%s", local_path, bucket, s3_key)

--- a/requirements-lambda.txt
+++ b/requirements-lambda.txt
@@ -1,0 +1,5 @@
+# Lambda-specific requirements.
+# boto3 is pre-installed in the Lambda runtime but included here so the
+# container image is self-contained and testable locally.
+-r requirements.txt
+boto3~=1.34.0

--- a/resolver.py
+++ b/resolver.py
@@ -13,9 +13,12 @@ from imports.cloud_ip_ranges import (
 from imports.domain_processor import process_domain_async
 
 
-async def main_async():
-    env_manager = EnvironmentManager()
-
+async def run(env_manager):
+    """
+    Core resolution pipeline. Accepts any EnvironmentManager-compatible object so
+    both the CLI entrypoint (resolver.py) and the Lambda entrypoint (lambda_handler.py)
+    can share the same logic.
+    """
     gcp_ipv4, gcp_ipv6 = fetch_google_cloud_ip_ranges(
         env_manager.get_output_dir(), env_manager.extreme
     )
@@ -104,6 +107,11 @@ async def main_async():
         )
         env_manager.log_info("Azure IPv4 Ranges: %s", csp_ip_addresses.get_azure_ipv4())
         env_manager.log_info("Azure IPv6 Ranges: %s", csp_ip_addresses.get_azure_ipv6())
+
+
+async def main_async():
+    env_manager = EnvironmentManager()
+    await run(env_manager)
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda_environment_manager.py
+++ b/tests/test_lambda_environment_manager.py
@@ -1,0 +1,120 @@
+"""Tests for LambdaEnvironmentManager."""
+
+import json
+import logging
+import os
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from classes.lambda_environment_manager import LambdaEnvironmentManager
+
+
+def _make_manager(tmp_path, domains_file=None, **kwargs):
+    """Helper: construct a LambdaEnvironmentManager with sensible test defaults."""
+    if domains_file is None:
+        d = tmp_path / "domains.txt"
+        d.write_text("example.com\n")
+        domains_file = str(d)
+
+    config = {
+        "config": {"timeout": 5, "retries": 2, "max_threads": 10, "output_dir": str(tmp_path)},
+        "domain_categorisation": {},
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    return LambdaEnvironmentManager(
+        domains_file=domains_file,
+        output_dir=str(tmp_path / "output"),
+        config_file=str(config_path),
+        **kwargs,
+    )
+
+
+def test_init_sets_domains_file(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.domains_file.endswith("domains.txt")
+
+
+def test_init_evidence_always_disabled(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.evidence is False
+
+
+def test_init_extreme_always_disabled(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.extreme is False
+
+
+def test_init_applies_config_defaults_for_timeout(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.timeout == 5
+
+
+def test_init_applies_config_defaults_for_retries(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.retries == 2
+
+
+def test_init_applies_config_defaults_for_max_threads(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.max_threads == 10
+
+
+def test_explicit_params_override_config_defaults(tmp_path):
+    mgr = _make_manager(tmp_path, timeout=30, retries=5, max_threads=100)
+    assert mgr.timeout == 30
+    assert mgr.retries == 5
+    assert mgr.max_threads == 100
+
+
+def test_nameservers_set_when_provided(tmp_path):
+    mgr = _make_manager(tmp_path, nameservers=["8.8.8.8", "1.1.1.1"])
+    assert mgr.nameservers == ["8.8.8.8", "1.1.1.1"]
+
+
+def test_nameservers_none_when_not_provided(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.nameservers is None
+
+
+def test_get_config_file_returns_configured_path(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.get_config_file().endswith("config.json")
+
+
+def test_logger_has_no_file_handler(tmp_path):
+    mgr = _make_manager(tmp_path)
+    handler_types = [type(h) for h in mgr.logger.handlers]
+    assert logging.FileHandler not in handler_types
+
+
+def test_logger_has_stream_handler(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert any(isinstance(h, logging.StreamHandler) for h in mgr.logger.handlers)
+
+
+def test_output_files_created(tmp_path):
+    mgr = _make_manager(tmp_path)
+    output_files = mgr.get_output_files()
+    assert "standard" in output_files
+    for key, path in output_files["standard"].items():
+        if key != "environment":  # JSON written separately
+            assert os.path.exists(path), f"Missing output file: {path}"
+
+
+def test_missing_config_file_uses_empty_config(tmp_path):
+    d = tmp_path / "domains.txt"
+    d.write_text("example.com\n")
+    mgr = LambdaEnvironmentManager(
+        domains_file=str(d),
+        output_dir=str(tmp_path / "output"),
+        config_file=str(tmp_path / "nonexistent.json"),
+    )
+    assert mgr.config == {}
+
+
+def test_environment_info_records_lambda_command(tmp_path):
+    mgr = _make_manager(tmp_path)
+    assert mgr.environment_info["command_executed"] == "lambda"

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,153 @@
+"""Tests for lambda_handler."""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+S3_EVENT = {
+    "Records": [
+        {
+            "s3": {
+                "bucket": {"name": "my-input-bucket"},
+                "object": {"key": "domains/domains.txt"},
+            }
+        }
+    ]
+}
+
+
+@pytest.fixture
+def mock_s3(tmp_path):
+    """Boto3 S3 client mock that writes a minimal domains file on download_file."""
+    client = MagicMock()
+
+    def fake_download(bucket, key, dest):
+        with open(dest, "w") as f:
+            f.write("example.com\n")
+
+    client.download_file.side_effect = fake_download
+    return client
+
+
+@pytest.fixture
+def mock_env_manager(tmp_path):
+    mgr = MagicMock()
+    mgr.get_output_dir.return_value = str(tmp_path / "output")
+    mgr.extreme = False
+    mgr.max_threads = 50
+    mgr.domains = {"example.com"}
+    mgr.get_retries.return_value = 0
+    mgr.get_extreme.return_value = False
+    os.makedirs(str(tmp_path / "output"), exist_ok=True)
+    return mgr
+
+
+async def test_handler_downloads_domains_from_s3(tmp_path, mock_s3, mock_env_manager):
+    with patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager), \
+         patch("lambda_handler.run", new_callable=AsyncMock), \
+         patch("lambda_handler._upload_results"), \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    mock_s3.download_file.assert_called_once_with(
+        "my-input-bucket",
+        "domains/domains.txt",
+        str(tmp_path / "domains.txt"),
+    )
+
+
+async def test_handler_uploads_results_after_run(tmp_path, mock_s3, mock_env_manager):
+    with patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager), \
+         patch("lambda_handler.run", new_callable=AsyncMock) as mock_run, \
+         patch("lambda_handler._upload_results") as mock_upload, \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    mock_run.assert_awaited_once()
+    mock_upload.assert_called_once()
+
+
+async def test_handler_uses_output_bucket_env_var(tmp_path, mock_s3, mock_env_manager):
+    with patch.dict(os.environ, {"OUTPUT_BUCKET": "my-output-bucket"}), \
+         patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager), \
+         patch("lambda_handler.run", new_callable=AsyncMock), \
+         patch("lambda_handler._upload_results") as mock_upload, \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    call_args = mock_upload.call_args[0]
+    assert call_args[2] == "my-output-bucket"
+
+
+async def test_handler_defaults_output_to_input_bucket(tmp_path, mock_s3, mock_env_manager):
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager), \
+         patch("lambda_handler.run", new_callable=AsyncMock), \
+         patch("lambda_handler._upload_results") as mock_upload, \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    call_args = mock_upload.call_args[0]
+    assert call_args[2] == "my-input-bucket"
+
+
+async def test_handler_parses_nameservers_env_var(tmp_path, mock_s3, mock_env_manager):
+    with patch.dict(os.environ, {"NAMESERVERS": "8.8.8.8,1.1.1.1"}), \
+         patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager) as MockEM, \
+         patch("lambda_handler.run", new_callable=AsyncMock), \
+         patch("lambda_handler._upload_results"), \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    _, kwargs = MockEM.call_args
+    assert kwargs.get("nameservers") == ["8.8.8.8", "1.1.1.1"]
+
+
+async def test_handler_passes_max_threads_env_var(tmp_path, mock_s3, mock_env_manager):
+    with patch.dict(os.environ, {"MAX_THREADS": "25"}), \
+         patch("lambda_handler.boto3.client", return_value=mock_s3), \
+         patch("lambda_handler.LambdaEnvironmentManager", return_value=mock_env_manager) as MockEM, \
+         patch("lambda_handler.run", new_callable=AsyncMock), \
+         patch("lambda_handler._upload_results"), \
+         patch("lambda_handler.TEMP_DIR", str(tmp_path)):
+
+        from lambda_handler import _main
+        await _main(S3_EVENT)
+
+    _, kwargs = MockEM.call_args
+    assert kwargs.get("max_threads") == 25
+
+
+def test_upload_results_walks_and_uploads(tmp_path):
+    result_dir = tmp_path / "results" / "20260509_120000"
+    result_dir.mkdir(parents=True)
+    (result_dir / "dangling.txt").write_text("example.com\n")
+    (result_dir / "resolved.txt").write_text("other.com|1.2.3.4\n")
+
+    mock_s3 = MagicMock()
+
+    from lambda_handler import _upload_results
+    _upload_results(mock_s3, str(result_dir), "my-bucket", "results")
+
+    assert mock_s3.upload_file.call_count == 2
+    uploaded_keys = {call[0][2] for call in mock_s3.upload_file.call_args_list}
+    assert any("dangling.txt" in k for k in uploaded_keys)
+    assert any("resolved.txt" in k for k in uploaded_keys)


### PR DESCRIPTION
## Summary

Adds a Lambda entrypoint that shares the same async DNS resolution pipeline as the CLI, with no duplication of resolution logic.

- **`resolver.py`** — core loop extracted into `run(env_manager)` so both entrypoints call the same function
- **`lambda_handler.py`** — S3-triggered entrypoint: download domains from S3 → `run()` → upload results back to S3; configured via environment variables
- **`classes/lambda_environment_manager.py`** — `EnvironmentManager` subclass for Lambda: accepts constructor params instead of argparse, logs to stdout (CloudWatch), disables evidence collection (no dig/nslookup in Lambda runtime), reads config defaults from bundled `config.json`
- **`Dockerfile`** — arm64 container image (chosen over Lambda layers due to pycares native extension)
- **`requirements-lambda.txt`** — base requirements + boto3

## Architecture decisions

| Decision | Choice | Reason |
|----------|--------|--------|
| Packaging | Container image | pycares native extension must match runtime arch |
| Architecture | arm64 (Graviton) | ~20% cheaper than x86_64 |
| Logging | stdout only | CloudWatch captures Lambda stdout automatically |
| Evidence collection | Disabled | dig/nslookup not in Lambda runtime |
| Intermediate storage | /tmp | Up to 10GB ephemeral; uploaded to S3 at end of run |

## Test plan

- [ ] `python -m pytest tests/ -q` — 138 tests, all passing
- [ ] `docker build --platform linux/arm64 -t dnsresolver-lambda .` — image builds cleanly
- [ ] Deploy to Lambda, drop a domains file in the input bucket, confirm results appear in S3

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)