### PR TITLE
Refactor EnvironmentManager into focused single-responsibility classes (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,8 +337,8 @@ Once related root domains are identified, enumerate subdomains for each and comb
 |-------|--------|-------------|
 | [#36](https://github.com/incendiary/DNSResolver/issues/36) | ✅ v1.1.1 | Progress bar stability — log output routed through `tqdm.write()` |
 | [#37](https://github.com/incendiary/DNSResolver/issues/37) | ✅ v1.2.0 | AWS Lambda / S3 support — `lambda_handler.py` entrypoint with S3 I/O |
-| [#41](https://github.com/incendiary/DNSResolver/issues/41) | 🔲 planned | Refactor `EnvironmentManager` into focused single-responsibility classes; replace Java-style getters with direct attribute access |
-| [#42](https://github.com/incendiary/DNSResolver/issues/42) | 🔲 planned | Enforce code style with Black, isort, flake8, and pre-commit hooks |
+| [#42](https://github.com/incendiary/DNSResolver/issues/42) | ✅ v1.2.1 | Enforce code style with Black, isort, flake8, and pre-commit hooks |
+| [#41](https://github.com/incendiary/DNSResolver/issues/41) | 🔄 v1.3.0 | Refactor `EnvironmentManager` — `ConfigResolver` + `OutputManager` split; trivial getters replaced with direct attribute access (PR open) |
 | [#43](https://github.com/incendiary/DNSResolver/issues/43) | 🔲 planned | Refactor `DNSHandler` — split resolution, takeover detection, and categorisation into focused classes |
 
 ## Contributing

--- a/classes/config_resolver.py
+++ b/classes/config_resolver.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+import logging
+import os
+import sys
+
+from classes.custom_exceptions import (
+    FileDoesNotExistError,
+    InvalidNameserversError,
+    NotAnIntegerError,
+)
+
+
+class ConfigResolver:
+    """Parses CLI arguments and merges them with values from config.json."""
+
+    def __init__(self):
+        self._logger = logging.getLogger("DNSResolver")
+        self.args = self._parse_args()
+        self._validate_args()
+        self._merge_config()
+        if self.args.extreme:
+            self.args.verbose = True
+
+    def _parse_args(self):
+        parser = argparse.ArgumentParser(
+            description="Resolve DNS records for domains and check against "
+            "cloud provider IP ranges."
+        )
+        parser.add_argument(
+            "domains_file",
+            type=str,
+            help="Path to the file containing domains (one per line)",
+        )
+        parser.add_argument(
+            "--config-file",
+            type=str,
+            default="config.json",
+            help="Path to the configuration file (default: config.json)",
+        )
+        parser.add_argument(
+            "--output-dir",
+            "-o",
+            type=str,
+            help="Directory to save output files (overrides config file)",
+        )
+        parser.add_argument(
+            "--verbose",
+            "-v",
+            action="store_true",
+            help="Enable verbose mode to display more information",
+        )
+        parser.add_argument(
+            "--extreme",
+            "-e",
+            action="store_true",
+            help="Enable extreme mode to display extensive information (including IP ranges)",
+        )
+        parser.add_argument(
+            "--nameservers",
+            type=str,
+            help="Comma-separated list of custom nameservers. Overrides system resolvers.",
+        )
+        parser.add_argument(
+            "--max-threads",
+            "-mt",
+            type=int,
+            help="Max number of threads to use for domain processing (overrides config file)",
+        )
+        parser.add_argument(
+            "--timeout",
+            "-t",
+            type=int,
+            help="Timeout for DNS resolution process in seconds (overrides config file)",
+        )
+        parser.add_argument(
+            "--retries",
+            type=int,
+            help="Number of retry attempts for timeouts (overrides config file)",
+        )
+        parser.add_argument(
+            "--evidence",
+            action="store_true",
+            help="Enable evidence collection for DNS queries (overrides config file)",
+        )
+        return parser.parse_args()
+
+    def _validate_args(self):
+        try:
+            if self.args.domains_file and not os.path.isfile(self.args.domains_file):
+                raise FileDoesNotExistError(
+                    f"Provided domains file does not exist: {self.args.domains_file}"
+                )
+            if self.args.max_threads and not isinstance(self.args.max_threads, int):
+                raise NotAnIntegerError(
+                    f"Provided max threads is not an integer: {self.args.max_threads}"
+                )
+            if self.args.timeout and not isinstance(self.args.timeout, int):
+                raise NotAnIntegerError(
+                    f"Provided timeout is not an integer: {self.args.timeout}"
+                )
+            if self.args.retries and not isinstance(self.args.retries, int):
+                raise NotAnIntegerError(
+                    f"Provided retries is not an integer: {self.args.retries}"
+                )
+            if self.args.nameservers and not all(
+                isinstance(i, str) for i in self.args.nameservers.split(",")
+            ):
+                raise InvalidNameserversError(
+                    f"Provided nameservers are not all strings: {self.args.nameservers}"
+                )
+        except (FileDoesNotExistError, NotAnIntegerError, InvalidNameserversError) as e:
+            self._logger.error(str(e))
+            sys.exit(1)
+
+    def _merge_config(self):
+        if not self.args.config_file:
+            return
+        try:
+            with open(self.args.config_file, "r", encoding="utf-8") as f:
+                config = json.load(f)
+        except (IOError, json.JSONDecodeError) as e:
+            self._logger.error("Error loading config file: %s", e)
+            config = {}
+
+        for key, value in config.get("config", {}).items():
+            if getattr(self.args, key, None) is None:
+                setattr(self.args, key, value)

--- a/classes/dns_handler.py
+++ b/classes/dns_handler.py
@@ -48,7 +48,7 @@ class DNSHandler:
         :param output_files: The output files configuration from the environment manager.
         :return: None
         """
-        evidence_enabled = self.env_manager.get_evidence()
+        evidence_enabled = self.env_manager.evidence
         if evidence_enabled:
             tasks = [
                 self.evidence_collector.perform_dns_evidence(
@@ -57,7 +57,7 @@ class DNSHandler:
                     reason,
                     output_files["evidence"]["dns"],
                 )
-                for nameserver in self.env_manager.get_resolvers()
+                for nameserver in self.env_manager.nameservers
             ]
 
             await asyncio.gather(*tasks)
@@ -72,7 +72,7 @@ class DNSHandler:
         :return: True if potential nameserver takeover is detected, False otherwise.
         """
         original_domain = domain_context.get_domain()
-        output_files = self.env_manager.get_output_files()
+        output_files = self.env_manager.output_files
 
         self.env_manager.log_info(f"Checking NS takeover for domain: {domain}")
 
@@ -238,7 +238,7 @@ class DNSHandler:
             message += f"|{additional_message}"
         self.env_manager.log_error(message)
         await self.env_manager.write_to_file(
-            self.env_manager.get_output_files()["standard"]["unresolved"],
+            self.env_manager.output_files["standard"]["unresolved"],
             message,
         )
 
@@ -251,7 +251,7 @@ class DNSHandler:
         """
         resolved_records = []
         current_domain = domain_context.get_domain()
-        retries = self.env_manager.get_retries()
+        retries = self.env_manager.retries
 
         self.env_manager.log_info(
             f"Starting DNS resolution for {current_domain} with {retries + 1} attempts."
@@ -298,7 +298,7 @@ class DNSHandler:
         :return: True if the domain is a dangling CNAME, False otherwise.
         """
         original_domain = domain_context.get_domain()
-        output_files = self.env_manager.get_output_files()
+        output_files = self.env_manager.output_files
 
         self.env_manager.log_info(
             f"Checking for dangling CNAME for domain: {current_domain}"
@@ -353,7 +353,7 @@ class DNSHandler:
         except aiodns.error.DNSError as e:
             self.env_manager.log_info(f"Error querying NS for {current_domain}: {e}")
 
-        patterns = self.env_manager.get_patterns()
+        patterns = self.env_manager.patterns
         category, recommendation, evidence_link = self.categorise_domain(
             current_domain, patterns
         )

--- a/classes/domain_processing_context.py
+++ b/classes/domain_processing_context.py
@@ -44,15 +44,15 @@ class DomainProcessingContext:
     def create_resolver(self):
         """Create and configure a DNS resolver object."""
         self.resolver = dns.resolver.Resolver()
-        self.resolver.lifetime = self.env_manager.get_timeout()
-        self.resolver.timeout = self.env_manager.get_timeout()
-        nameservers = self.env_manager.get_resolvers()
+        self.resolver.lifetime = self.env_manager.timeout
+        self.resolver.timeout = self.env_manager.timeout
+        nameservers = self.env_manager.nameservers
         if nameservers:
             self.resolver.nameservers = nameservers
 
     def log_info(self, message, *args):
         """Log an info message or print to stdout if logger is not available."""
-        logger = self.env_manager.get_logger()
+        logger = self.env_manager.logger
         if logger:
             logger.info(message, *args)
         else:

--- a/classes/environment_manager.py
+++ b/classes/environment_manager.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import logging
 import os
@@ -7,30 +6,16 @@ import re
 import sys
 from datetime import datetime
 
-import aiofiles
 import requests
 from requests import RequestException
 from tqdm import tqdm
 
-from classes.custom_exceptions import (
-    FileDoesNotExistError,
-    InvalidNameserversError,
-    NotAnIntegerError,
-)
-
-
-async def write_to_file(file_path, content):
-    logger = logging.getLogger("DNSResolver")
-    try:
-        async with aiofiles.open(file_path, "a", encoding="utf-8") as f:
-            await f.write(content + "\n")
-        logger.info(f"Successfully wrote to {file_path}")
-    except Exception as e:
-        logger.error(f"Failed to write to {file_path}: {e}")
+from classes.config_resolver import ConfigResolver
+from classes.output_manager import OutputManager
 
 
 class TqdmLoggingHandler(logging.StreamHandler):
-    """Routes log output through tqdm.write() so the progress bar stays pinned to the bottom."""
+    """Routes log output through tqdm.write() so the progress bar stays pinned."""
 
     def emit(self, record):
         try:
@@ -40,273 +25,79 @@ class TqdmLoggingHandler(logging.StreamHandler):
 
 
 def setup_logger(log_file="dnsresolver.log", verbose=False):
-    """
-    Set up a logger for DNSResolver.
-    :param log_file: The log file path.
-    :param verbose: Enable verbose mode for console logging.
-    :return: Logger object.
-    """
     logger = logging.getLogger("DNSResolver")
     logger.setLevel(logging.INFO)
-
     if logger.hasHandlers():
         logger.handlers.clear()
-
     ch = TqdmLoggingHandler()
-    ch.setLevel(logging.CRITICAL)  # Suppress console output by default
-
+    ch.setLevel(logging.INFO if verbose else logging.CRITICAL)
     fh = logging.FileHandler(log_file)
     fh.setLevel(logging.INFO)
-
     formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     ch.setFormatter(formatter)
     fh.setFormatter(formatter)
-
     logger.addHandler(ch)
     logger.addHandler(fh)
-
-    if verbose:
-        ch.setLevel(logging.INFO)
-
     logger.info("Logger initialized.")
-
     return logger
 
 
 class EnvironmentManager:
-    """
-    EnvironmentManager Class
-    ------------------------
-
-    Class for managing the environment configuration and setup.
-
-    Attributes:
-        config (dict): A dictionary containing the configuration parameters.
-        args (argparse.Namespace): An object containing the command line arguments.
-        logger (Logger): An instance of a logger for logging messages.
-        domains_file (str): The path to the file containing the domains.
-        output_dir (str): The directory to save output files.
-        verbose (bool): Flag indicating whether to enable verbose mode.
-        extreme (bool): Flag indicating whether to enable extreme mode.
-        nameservers (list): A list of custom nameservers.
-        max_threads (int): The maximum number of threads to use for domain processing.
-        timeout (int): The timeout for the DNS resolution process in seconds.
-        retries (int): The number of retry attempts for timeouts.
-        evidence (bool): Flag indicating whether to enable evidence collection for DNS queries.
-        output_files (list): A list of output file paths.
-        timestamp (str): The current timestamp.
-        environment_info (dict): A dictionary containing environment information.
-        domains (list): A list of domains to process.
-
-    Methods:
-        __init__(): Initialize the EnvironmentManager class.
-        argument_parsing(): Parse the command line arguments.
-        validate_arguments(): Validate the command line arguments.
-        resolve_effective_configuration(): Resolve the effective configuration.
-        log_effective_configuration(): Log the effective configuration.
-    """
+    """Thin orchestrator: wires ConfigResolver, OutputManager, logging, and domain I/O."""
 
     def __init__(self):
-        self.config = {}
-        self.args = None
         self.logger = setup_logger()
-        self.domains_file = None
-        self.output_dir = None
-        self.verbose = None
-        self.extreme = None
-        self.nameservers = None
-        self.max_threads = None
-        self.timeout = None
-        self.retries = None
-        self.evidence = None
-        self.output_files = None
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.environment_info = {
-            "command_executed": None,
-            "external_ip": None,
-            "run_in_docker": None,
-        }
         self.domains = set()
         self.patterns = None
+        self.environment_info = {}
 
-        # Default Actions
-        # Get our arguments
-        self.argument_parsing()
-        # validate arguments
-        self.validate_arguments()
-        # Cross compare with config file arguments and resolve
-        self.resolve_effective_configuration()
-        # Transfer the arguments to class attributes
-        self.set_arguments()
-        # log the effective arguments
+        cfg = ConfigResolver()
+        self.args = cfg.args
+        self._config_file = cfg.args.config_file
+        self.domains_file = cfg.args.domains_file
+        self.output_dir = cfg.args.output_dir
+        self.verbose = cfg.args.verbose
+        self.extreme = cfg.args.extreme
+        self.nameservers = (
+            cfg.args.nameservers.split(",") if cfg.args.nameservers else None
+        )
+        self.max_threads = cfg.args.max_threads
+        self.timeout = cfg.args.timeout
+        self.retries = cfg.args.retries
+        self.evidence = cfg.args.evidence
+
         self.log_effective_configuration()
-        # Setup the environment
-        self.initialise_environment()
-        # save our environment json file for future reference
-        self.save_environment_info()
-        # Load patterns after environment initialization
-        self.load_patterns()
+        if self.verbose:
+            self.update_logger()
 
+        om = OutputManager(self.output_dir, self.timestamp, self.evidence)
+        self.output_dir = om.output_dir
+        self.output_files = om.output_files
+        self.write_to_file = om.write_to_file
+
+        self._populate_environment_info()
+        self.save_environment_info()
+        self.load_patterns()
         self.logger.info("EnvironmentManager initialized.")
 
-    def argument_parsing(self):
-        """
-        Parses command-line arguments. Available options include domains file, config file,
-        output directory, verbose and extreme mode, custom nameservers, service checks,
-        max threads, timeout, retries, and evidence collection.
-        """
-        parser = argparse.ArgumentParser(
-            description="Resolve DNS records for domains and check against "
-            "cloud provider IP ranges."
-        )
-        parser.add_argument(
-            "domains_file",
-            type=str,
-            help="Path to the file containing domains (one per line)",
-        )
-        parser.add_argument(
-            "--config-file",
-            type=str,
-            default="config.json",
-            help="Path to the configuration file (default: config.json)",
-        )
-        parser.add_argument(
-            "--output-dir",
-            "-o",
-            type=str,
-            help="Directory to save output files (overrides config file)",
-        )
-        parser.add_argument(
-            "--verbose",
-            "-v",
-            action="store_true",
-            help="Enable verbose mode to display more information",
-        )
-        parser.add_argument(
-            "--extreme",
-            "-e",
-            action="store_true",
-            help="Enable extreme mode to display extensive information (including IP ranges)",
-        )
-        parser.add_argument(
-            "--nameservers",
-            type=str,
-            help="Comma-separated list of custom nameservers. Overrides system resolvers.",
-        )
-        parser.add_argument(
-            "--max-threads",
-            "-mt",
-            type=int,
-            help="Max number of threads to use for domain processing (overrides config file)",
-        )
-        parser.add_argument(
-            "--timeout",
-            "-t",
-            type=int,
-            help="Timeout for DNS resolution process in seconds (overrides config file)",
-        )
-        parser.add_argument(
-            "--retries",
-            type=int,
-            help="Number of retry attempts for timeouts (overrides config file)",
-        )
-        parser.add_argument(
-            "--evidence",
-            action="store_true",
-            help="Enable evidence collection for DNS queries (overrides config file)",
-        )
-        self.args = parser.parse_args()
+    def get_config_file(self):
+        return self._config_file
 
-    def validate_arguments(self):
-        """
-        Checks validity of runtime arguments. Raises respective exceptions for issues in input args.
-        """
-        try:
-            if self.args.domains_file and not os.path.isfile(self.args.domains_file):
-                raise FileDoesNotExistError(
-                    f"Provided domains file does not exist: {self.args.domains_file}"
-                )
-            if self.args.max_threads and not isinstance(self.args.max_threads, int):
-                raise NotAnIntegerError(
-                    f"Provided max threads is not an integer: {self.args.max_threads}"
-                )
-            if self.args.timeout and not isinstance(self.args.timeout, int):
-                raise NotAnIntegerError(
-                    f"Provided timeout is not an integer: {self.args.timeout}"
-                )
-            if self.args.retries and not isinstance(self.args.retries, int):
-                raise NotAnIntegerError(
-                    f"Provided retries is not an integer: {self.args.retries}"
-                )
-            if self.args.nameservers and not all(
-                isinstance(i, str) for i in self.args.nameservers.split(",")
-            ):
-                raise InvalidNameserversError(
-                    f"Provided nameservers are not all strings: {self.args.nameservers}"
-                )
-        except (FileDoesNotExistError, NotAnIntegerError, InvalidNameserversError) as e:
-            self.logger.error(str(e))
-            sys.exit(1)
-
-    def resolve_effective_configuration(self):
-        # This function prioritizes command line arguments, falling back to
-        # config file values if corresponding CLI arguments are not set
-
-        # Check if a config file is specified in the command line arguments
-        if self.args.config_file:
-            # Attempt to open and read the config file
-            try:
-                with open(self.args.config_file, "r", encoding="utf-8") as f:
-                    try:
-                        # Load the JSON data from the config file
-                        self.config = json.load(f)
-                    except json.JSONDecodeError as err:
-                        # If an error occurs during JSON loading, log the error and assign
-                        # an empty dictionary to self.config
-                        self.logger.error("Error parsing JSON: %s", err)
-                        self.config = {}
-
-            # Handle file opening errors
-            except IOError as e:
-                self.logger.error("Error opening file: %s", e)
-                self.config = {}
-
-            # Retrieve the configuration parameters from the loaded configuration file.
-            config_args = self.config.get("config", {})
-
-            # Iterate over each item in the configuration data
-            for key, value in config_args.items():
-                # Check if the argument was provided as a command line argument.
-                # If not, use the value from the configuration file.
-                if getattr(self.args, key, None) is None:
-                    setattr(self.args, key, value)
-
-        # If the 'extreme' argument is provided, also set 'verbose' to True
-        if self.args.extreme:
-            self.args.verbose = True
+    def get_random_nameserver(self):
+        if self.nameservers:
+            return random.choice(self.nameservers)
+        return None
 
     def update_logger(self):
-        """
-        Updates the logger based on the verbosity supplied.
-        """
-        if self.verbose:  # If verbose flag is true
-            for handler in self.logger.handlers:
-                if isinstance(handler, logging.StreamHandler):
-                    handler.setLevel(logging.INFO)  # Set console logging level to INFO
-        else:
-            for handler in self.logger.handlers:
-                if isinstance(handler, logging.StreamHandler):
-                    handler.setLevel(logging.CRITICAL)  # Suppress console logging
-
-        # Test logging to verify the update
+        for handler in self.logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                handler.setLevel(logging.INFO)
         self.logger.info("Logger updated based on verbosity.")
 
     def log_effective_configuration(self):
-        """
-        Logs the effective configuration and prints some additional banner information.
-        """
         self.logger.info("Effective Configuration: %s", vars(self.args))
         banner = """
 ░▒▓███████▓▒░░▒▓████████▓▒░░▒▓███████▓▒░░▒▓██████▓▒░░▒▓█▓▒░   ░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░▒▓███████▓▒░
@@ -322,116 +113,7 @@ class EnvironmentManager:
         for key, value in vars(self.args).items():
             print(f"{key:20}: {value}")
 
-    def set_arguments(self):
-        """
-        Sets instance variable values based on runtime arguments.
-        """
-        self.domains_file = self.args.domains_file
-        self.output_dir = self.args.output_dir
-        self.verbose = self.args.verbose
-        self.extreme = self.args.extreme
-        self.max_threads = self.args.max_threads
-        self.timeout = self.args.timeout
-        self.retries = self.args.retries
-        self.evidence = self.args.evidence
-
-        self.logger.info(
-            "Arguments set: domains_file=%s, output_dir=%s, verbose=%s, extreme=%s,"
-            " max_threads=%s, timeout=%s, retries=%s, evidence=%s",
-            self.domains_file,
-            self.output_dir,
-            self.verbose,
-            self.extreme,
-            self.max_threads,
-            self.timeout,
-            self.retries,
-            self.evidence,
-        )
-
-        if self.args.nameservers:
-            self.nameservers = self.args.nameservers.split(",")
-            self.logger.info("Nameservers set: %s", self.nameservers)
-
-        # Only update logger if verbose flag is true
-        if self.verbose:
-            self.logger.info("Verbose mode enabled, updating logger.")
-            self.update_logger()
-
-    def initialise_environment(self):
-        """
-        Prepares the environment by setting paths, creating directories, and initializing files.
-        """
-
-        self.output_dir = os.path.join(self.output_dir, self.timestamp)
-
-        os.makedirs(self.output_dir, exist_ok=True)
-
-        output_files = {
-            "standard": {
-                "resolved": os.path.join(
-                    self.output_dir, f"resolution_results_{self.timestamp}.txt"
-                ),
-                "unresolved": os.path.join(
-                    self.output_dir, f"unresolved_results_{self.timestamp}.txt"
-                ),
-                "gcp": os.path.join(
-                    self.output_dir, f"gcp_results_{self.timestamp}.txt"
-                ),
-                "aws": os.path.join(
-                    self.output_dir, f"aws_results_{self.timestamp}.txt"
-                ),
-                "azure": os.path.join(
-                    self.output_dir, f"azure_results_{self.timestamp}.txt"
-                ),
-                "dangling": os.path.join(
-                    self.output_dir,
-                    f"dangling_cname_results_{self.timestamp}.txt",
-                ),
-                "ns_takeover": os.path.join(
-                    self.output_dir, f"ns_takeover_results_{self.timestamp}.txt"
-                ),
-                "environment": os.path.join(
-                    self.output_dir, f"environment_results_{self.timestamp}.json"
-                ),
-                "timeout": os.path.join(
-                    self.output_dir, f"timeout_results_{self.timestamp}.txt"
-                ),
-            }
-        }
-
-        if self.evidence:
-            output_files["evidence"] = {
-                "dns": os.path.join(self.output_dir, "evidence", "dns"),
-            }
-
-        self.output_files = output_files
-        self.create_empty_files_or_directories()
-
-        # Log the creation of each file
-        for category, files in output_files.items():
-            for description, path in files.items():
-                if os.path.exists(path):
-                    self.logger.info(f"Successfully created file: {path}")
-                else:
-                    self.logger.error(f"Failed to create file: {path}")
-
-    def save_environment_info(self):
-        """
-        Stores environment details such as command invoked, external IP and running condition.
-        """
-        self.get_environment_info()
-        with open(
-            self.output_files["standard"]["environment"], "w", encoding="utf-8"
-        ) as json_file:
-            json_file.write(json.dumps(self.environment_info, indent=4))
-
-    def get_environment_info(self):
-        """
-        Retrieves environment details such as command executed, external IP, and docker status.
-        """
-        command_executed = " ".join(sys.argv)
-        running_in_docker = os.path.exists("/.dockerenv")
-
+    def _populate_environment_info(self):
         try:
             response = requests.get("https://ifconfig.io/ip", timeout=10)
             external_ip = response.text.strip()
@@ -439,91 +121,35 @@ class EnvironmentManager:
             external_ip = (
                 f"An error occurred while trying to retrieve the external ip: {error}"
             )
-
-        environment_info = {
-            "command_executed": command_executed,
+        self.environment_info = {
+            "command_executed": " ".join(sys.argv),
             "external_ip": external_ip,
-            "run_in_docker": running_in_docker,
+            "run_in_docker": os.path.exists("/.dockerenv"),
         }
 
-        self.environment_info = environment_info
+    def save_environment_info(self):
+        env_path = self.output_files["standard"]["environment"]
+        with open(env_path, "w", encoding="utf-8") as f:
+            json.dump(self.environment_info, f, indent=4)
 
-    def create_empty_file_or_directory(self, filename):
-        """
-        Creates an empty file or directory given a filename or directory path.
-        """
-        if not isinstance(filename, str):
-            raise ValueError("filename must be a string")
-
-        _, extension = os.path.splitext(filename)
-
+    def load_patterns(self):
         try:
-            if not extension:
-                os.makedirs(filename, exist_ok=True)
-            else:
-                with open(filename, "w", encoding="utf-8"):
-                    pass
-        except (IOError, OSError) as e:
-            self.logger.error(
-                "Unable to create file or directory %s. Error: %s", filename, e
-            )
-
-    def create_empty_files_or_directories(
-        self,
-    ):
-        """
-        Generates all required output files and directories based on the given settings.
-        """
-        for _, value in self.output_files.get("standard", {}).items():
-            self.create_empty_file_or_directory(value)
-
-        if "evidence" in self.output_files:
-            for value in self.output_files["evidence"].values():
-                self.create_empty_file_or_directory(value)
-
-        # Log the creation of each file
-        for category, files in self.output_files.items():
-            for description, path in files.items():
-                if os.path.exists(path):
-                    self.logger.info(f"Successfully created file: {path}")
-                else:
-                    self.logger.error(f"Failed to create file: {path}")
-
-    async def write_to_file(self, file_path, content):
-        try:
-            async with aiofiles.open(file_path, "a", encoding="utf-8") as f:
-                await f.write(content + "\n")
-            self.logger.info(f"Successfully wrote to {file_path}")
-        except Exception as e:
-            self.logger.error(f"Failed to write to {file_path}: {e}")
+            with open(self._config_file, "r", encoding="utf-8") as f:
+                config = json.load(f)
+            self.patterns = config.get("domain_categorisation", {})
+        except (IOError, json.JSONDecodeError):
+            self.patterns = {}
 
     def set_domains(self):
-        """
-        Reads and sets the domains from the file specified in runtime arguments.
-        """
         with open(self.domains_file, "r", encoding="utf-8") as f:
             raw_domains = f.read().splitlines()
-            self.domains = set(self.clean_domains(raw_domains))  # Convert list to set
+        self.domains = set(self.clean_domains(raw_domains))
 
     def clean_domains(self, domains):
-        """
-        Cleans the domain list by removing empty lines and invalid DNS labels.
-        :param domains: The list of domains to be cleaned.
-        :return: A cleaned list of domains.
-        """
-        valid_domains = []
-        for domain in domains:
-            if domain and self.is_valid_domain(domain):
-                valid_domains.append(domain)
-        return valid_domains
+        return [d for d in domains if d and self.is_valid_domain(d)]
 
     @staticmethod
     def is_valid_domain(domain):
-        """
-        Checks if a given domain is a valid DNS label.
-        :param domain: The domain to validate.
-        :return: True if valid, False otherwise.
-        """
         regex = re.compile(
             r"^(?=.{1,253}$)"
             r"(?:(?!\d+$)[a-zA-Z\d]([a-zA-Z\d-]{0,61}[a-zA-Z\d])?\.)+"
@@ -532,128 +158,7 @@ class EnvironmentManager:
         return bool(regex.match(domain))
 
     def log_info(self, message, *args):
-        """
-        Logs an informational message. If logger is not set, simply prints the info.
-        """
-        if self.logger:
-            self.logger.info(message, *args)
-        else:
-            print(f"INFO: {message % args}")
+        self.logger.info(message, *args)
 
     def log_error(self, message, *args):
-        """
-        Logs an informational message. If logger is not set, simply prints the info.
-        """
-        if self.logger:
-            self.logger.error(message, *args)
-        else:
-            print(f"ERROR: {message % args}")
-
-    def get_nameservers(self):
-        """
-        Retrieve the list of custom nameservers.
-        :return: A list of custom nameservers.
-        :rtype: list
-        """
-        return self.nameservers
-
-    def get_random_nameserver(self):
-        """
-        Returns a random nameserver from the list of custom nameservers.
-        :return: A random nameserver.
-        :rtype: str
-        """
-        if self.nameservers:
-            return random.choice(self.nameservers)
-        return None
-
-    def load_patterns(self):
-        """
-        Load domain categorisation patterns from the given config file and set to self.patterns.
-        """
-        config_file = self.get_config_file()
-        with open(config_file, "r", encoding="utf-8") as f:
-            config = json.load(f)
-        self.patterns = config.get("domain_categorisation", {})
-
-    # Simple Getters and setters
-
-    def get_patterns(self):
-        """
-        Retrieve the loaded domain categorisation patterns.
-        :return: A dictionary of domain categorisation patterns.
-        :rtype: dict
-        """
-        return self.patterns
-
-    def get_output_files(self):
-        return self.output_files
-
-    def get_logger(self):
-        return self.logger
-
-    def get_domains(self):
-        return self.domains
-
-    def get_domains_file(self):
-        return self.domains_file
-
-    def set_domains_file(self, domains_file):
-        self.domains_file = domains_file
-
-    def get_output_dir(self):
-        return self.output_dir
-
-    def set_output_dir(self, output_dir):
-        self.output_dir = output_dir
-
-    def get_verbose(self):
-        return self.verbose
-
-    def set_verbose(self, verbose):
-        self.verbose = verbose
-
-    def get_extreme(self):
-        return self.extreme
-
-    def set_extreme(self, extreme):
-        self.extreme = extreme
-
-    def get_resolvers(self):
-        return self.nameservers
-
-    def set_resolvers(self, resolvers):
-        self.nameservers = resolvers
-
-    def get_max_threads(self):
-        return self.max_threads
-
-    def set_max_threads(self, max_threads):
-        self.max_threads = max_threads
-
-    def get_timeout(self):
-        return self.timeout
-
-    def set_timeout(self, timeout):
-        self.timeout = timeout
-
-    def get_retries(self):
-        return self.retries
-
-    def set_retries(self, retries):
-        self.retries = retries
-
-    def get_evidence(self):
-        return self.evidence
-
-    def set_evidence(self, evidence):
-        self.evidence = evidence
-
-    def get_timestamp(self):
-        return self.timestamp
-
-    def set_timestamp(self, timestamp):
-        self.timestamp = timestamp
-
-    def get_config_file(self):
-        return self.args.config_file
+        self.logger.error(message, *args)

--- a/classes/lambda_environment_manager.py
+++ b/classes/lambda_environment_manager.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 
 from classes.environment_manager import EnvironmentManager
+from classes.output_manager import OutputManager
 
 
 class LambdaEnvironmentManager(EnvironmentManager):
@@ -10,8 +11,7 @@ class LambdaEnvironmentManager(EnvironmentManager):
     EnvironmentManager variant for AWS Lambda.
 
     Differences from the CLI version:
-      - Config comes from constructor parameters and environment variables,
-        not argparse / sys.argv.
+      - Config comes from constructor parameters, not argparse / sys.argv.
       - Logs to stdout only (CloudWatch captures Lambda stdout automatically);
         no log file is created.
       - Evidence collection is disabled — dig/nslookup are not available in
@@ -33,22 +33,13 @@ class LambdaEnvironmentManager(EnvironmentManager):
         verbose=False,
     ):
         # Initialise base attributes directly — do NOT call super().__init__()
-        # because that triggers argparse which has no meaning in Lambda.
-        self.config = {}
-        self.args = None
+        # because that triggers ConfigResolver / argparse, which has no meaning in Lambda.
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.environment_info = {
-            "command_executed": "lambda",
-            "external_ip": None,
-            "run_in_docker": False,
-        }
         self.domains = set()
         self.patterns = None
-        self.output_files = None
         self._config_file = config_file
 
         self.domains_file = domains_file
-        self.output_dir = output_dir
         self.verbose = verbose
         self.extreme = False
         self.nameservers = nameservers if nameservers else None
@@ -58,18 +49,26 @@ class LambdaEnvironmentManager(EnvironmentManager):
         self.evidence = False  # dig/nslookup not available in Lambda runtime
 
         self.logger = self._setup_lambda_logger(verbose)
-
         self._load_config(config_file)
         self._apply_config_defaults()
 
-        self.initialise_environment()
+        om = OutputManager(output_dir, self.timestamp, evidence=False)
+        self.output_dir = om.output_dir
+        self.output_files = om.output_files
+        self.write_to_file = om.write_to_file
+
+        self.environment_info = {
+            "command_executed": "lambda",
+            "external_ip": None,
+            "run_in_docker": False,
+        }
         self.save_environment_info()
         self.load_patterns()
 
         self.logger.info("LambdaEnvironmentManager initialized.")
 
     # ------------------------------------------------------------------
-    # Overrides
+    # Lambda-specific helpers (not overrides of EnvironmentManager logic)
     # ------------------------------------------------------------------
 
     def _setup_lambda_logger(self, verbose=False):
@@ -96,7 +95,6 @@ class LambdaEnvironmentManager(EnvironmentManager):
             self.config = {}
 
     def _apply_config_defaults(self):
-        """Fill in any unset values from config.json."""
         config_args = self.config.get("config", {})
         if self.timeout is None:
             self.timeout = config_args.get("timeout")
@@ -105,17 +103,9 @@ class LambdaEnvironmentManager(EnvironmentManager):
         if self.max_threads is None:
             self.max_threads = config_args.get("max_threads", 50)
 
-    def load_patterns(self):
-        """Override to handle missing config file gracefully."""
-        try:
-            with open(self._config_file, "r", encoding="utf-8") as f:
-                config = json.load(f)
-            self.patterns = config.get("domain_categorisation", {})
-        except (IOError, json.JSONDecodeError):
-            self.patterns = {}
-
-    def get_config_file(self):
-        return self._config_file
+    # ------------------------------------------------------------------
+    # Override: Lambda-specific formatting only
+    # ------------------------------------------------------------------
 
     def log_effective_configuration(self):
         self.logger.info(
@@ -128,9 +118,3 @@ class LambdaEnvironmentManager(EnvironmentManager):
             self.retries,
             self.verbose,
         )
-
-    def save_environment_info(self):
-        """Write environment JSON to the local output dir (will be uploaded to S3 by caller)."""
-        env_path = self.output_files["standard"]["environment"]
-        with open(env_path, "w", encoding="utf-8") as f:
-            json.dump(self.environment_info, f, indent=4)

--- a/classes/output_manager.py
+++ b/classes/output_manager.py
@@ -1,0 +1,59 @@
+import logging
+import os
+
+import aiofiles
+
+
+class OutputManager:
+    """Creates the output directory structure and handles async file writes."""
+
+    def __init__(self, base_output_dir, timestamp, evidence=False):
+        self._logger = logging.getLogger("DNSResolver")
+        self.output_dir = os.path.join(base_output_dir, timestamp)
+        os.makedirs(self.output_dir, exist_ok=True)
+        self.output_files = self._build_output_files(timestamp, evidence)
+        self._create_all()
+
+    def _build_output_files(self, timestamp, evidence):
+        d = self.output_dir
+        files = {
+            "standard": {
+                "resolved": os.path.join(d, f"resolution_results_{timestamp}.txt"),
+                "unresolved": os.path.join(d, f"unresolved_results_{timestamp}.txt"),
+                "gcp": os.path.join(d, f"gcp_results_{timestamp}.txt"),
+                "aws": os.path.join(d, f"aws_results_{timestamp}.txt"),
+                "azure": os.path.join(d, f"azure_results_{timestamp}.txt"),
+                "dangling": os.path.join(d, f"dangling_cname_results_{timestamp}.txt"),
+                "ns_takeover": os.path.join(d, f"ns_takeover_results_{timestamp}.txt"),
+                "environment": os.path.join(d, f"environment_results_{timestamp}.json"),
+                "timeout": os.path.join(d, f"timeout_results_{timestamp}.txt"),
+            }
+        }
+        if evidence:
+            files["evidence"] = {"dns": os.path.join(d, "evidence", "dns")}
+        return files
+
+    def _create_all(self):
+        for path in self.output_files.get("standard", {}).values():
+            self._create(path)
+        if "evidence" in self.output_files:
+            for path in self.output_files["evidence"].values():
+                self._create(path)
+
+    def _create(self, path):
+        _, ext = os.path.splitext(path)
+        try:
+            if not ext:
+                os.makedirs(path, exist_ok=True)
+            else:
+                with open(path, "w", encoding="utf-8"):
+                    pass
+        except (IOError, OSError) as e:
+            self._logger.error("Unable to create %s: %s", path, e)
+
+    async def write_to_file(self, file_path, content):
+        try:
+            async with aiofiles.open(file_path, "a", encoding="utf-8") as f:
+                await f.write(content + "\n")
+        except Exception as e:
+            self._logger.error("Failed to write to %s: %s", file_path, e)

--- a/imports/cloud_service_provider_checks.py
+++ b/imports/cloud_service_provider_checks.py
@@ -53,7 +53,7 @@ def perform_csp_checks(domain_context, env_manager, final_ips):
     :return: None
     """
     domain = domain_context.get_domain()
-    output_files = env_manager.get_output_files()
+    output_files = env_manager.output_files
 
     vendor_ips_context_ipv4 = get_vendor_ips(domain_context, ip_version=4)
     vendor_ips_context_ipv6 = get_vendor_ips(domain_context, ip_version=6)

--- a/imports/domain_processor.py
+++ b/imports/domain_processor.py
@@ -19,7 +19,7 @@ async def process_domain_async(
     )
 
     if success and final_ips:
-        output_files = env_manager.get_output_files()
+        output_files = env_manager.output_files
         await env_manager.write_to_file(
             output_files["standard"]["resolved"],
             f"{domain}|{'|'.join(final_ips)}",

--- a/lambda_handler.py
+++ b/lambda_handler.py
@@ -77,7 +77,7 @@ async def _main(event):
 
     await run(env_manager)
 
-    _upload_results(s3, env_manager.get_output_dir(), output_bucket, output_prefix)
+    _upload_results(s3, env_manager.output_dir, output_bucket, output_prefix)
     logger.info("Results uploaded to s3://%s/%s/", output_bucket, output_prefix)
 
 

--- a/resolver.py
+++ b/resolver.py
@@ -20,13 +20,13 @@ async def run(env_manager):
     can share the same logic.
     """
     gcp_ipv4, gcp_ipv6 = fetch_google_cloud_ip_ranges(
-        env_manager.get_output_dir(), env_manager.extreme
+        env_manager.output_dir, env_manager.extreme
     )
     aws_ipv4, aws_ipv6 = fetch_aws_ip_ranges(
-        env_manager.get_output_dir(), env_manager.extreme
+        env_manager.output_dir, env_manager.extreme
     )
     azure_ipv4, azure_ipv6 = fetch_azure_ip_ranges(
-        env_manager.get_output_dir(), env_manager.extreme
+        env_manager.output_dir, env_manager.extreme
     )
 
     csp_ip_addresses = CSPIPAddresses(
@@ -35,7 +35,7 @@ async def run(env_manager):
 
     env_manager.set_domains()
     domains_to_process = list(env_manager.domains)
-    retries = env_manager.get_retries()
+    retries = env_manager.retries
     dns_handler = DNSHandler(env_manager)
     sem = asyncio.Semaphore(env_manager.max_threads or 50)
     all_dangling_domains: set = set()
@@ -93,10 +93,10 @@ async def run(env_manager):
         )
 
     env_manager.log_info(
-        "All resolutions completed. Results saved to %s", env_manager.get_output_dir()
+        "All resolutions completed. Results saved to %s", env_manager.output_dir
     )
 
-    if env_manager.get_extreme():
+    if env_manager.extreme:
         env_manager.log_info("AWS IPv4 Ranges: %s", csp_ip_addresses.get_aws_ipv4())
         env_manager.log_info("AWS IPv6 Ranges: %s", csp_ip_addresses.get_aws_ipv6())
         env_manager.log_info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,15 +48,15 @@ def mock_env_manager():
     """
     env = MagicMock()
 
-    # DNS / resolver config
-    env.get_random_nameserver.return_value = None
-    env.get_resolvers.return_value = ["8.8.8.8"]
-    env.get_retries.return_value = 2
-    env.get_timeout.return_value = 5
-    env.get_evidence.return_value = False
+    # DNS / resolver config — direct attribute access (no getters)
+    env.get_random_nameserver.return_value = None  # method with logic, kept as method
+    env.nameservers = ["8.8.8.8"]
+    env.retries = 2
+    env.timeout = 5
+    env.evidence = False
 
     # Output files the handler writes results to
-    env.get_output_files.return_value = {
+    env.output_files = {
         "standard": {
             "dangling": "/tmp/test_dangling.txt",
             "ns_takeover": "/tmp/test_ns_takeover.txt",
@@ -67,7 +67,7 @@ def mock_env_manager():
     }
 
     # Domain categorisation patterns (empty → every domain is "unknown")
-    env.get_patterns.return_value = {}
+    env.patterns = {}
 
     # write_to_file is async, so it needs AsyncMock not MagicMock
     env.write_to_file = AsyncMock()

--- a/tests/test_cloud_service_provider_checks.py
+++ b/tests/test_cloud_service_provider_checks.py
@@ -205,7 +205,7 @@ def test_perform_csp_checks_matches_gcp_ip(tmp_path, mock_env_manager, ctx):
     aws_file.touch()
     azure_file = tmp_path / "azure.txt"
     azure_file.touch()
-    mock_env_manager.get_output_files.return_value = {
+    mock_env_manager.output_files = {
         "standard": {
             "gcp": str(gcp_file),
             "aws": str(aws_file),
@@ -222,7 +222,7 @@ def test_perform_csp_checks_matches_gcp_ip(tmp_path, mock_env_manager, ctx):
 def test_perform_csp_checks_no_match_returns_false(tmp_path, mock_env_manager, ctx):
     for vendor in ("gcp", "aws", "azure"):
         (tmp_path / f"{vendor}.txt").touch()
-    mock_env_manager.get_output_files.return_value = {
+    mock_env_manager.output_files = {
         "standard": {
             "gcp": str(tmp_path / "gcp.txt"),
             "aws": str(tmp_path / "aws.txt"),

--- a/tests/test_dns_handler.py
+++ b/tests/test_dns_handler.py
@@ -174,7 +174,7 @@ async def test_resolve_domain_async_retries_before_giving_up(
     The handler should attempt the query (retries + 1) times before
     declaring failure.  We configure 2 retries, so expect 3 total calls.
     """
-    mock_env_manager.get_retries.return_value = 2
+    mock_env_manager.retries = 2
     handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
     handler.handle_domain_resolution_errors = AsyncMock(return_value=(False, []))
 

--- a/tests/test_dns_handler_extended.py
+++ b/tests/test_dns_handler_extended.py
@@ -88,8 +88,8 @@ async def test_log_and_write_dns_error_includes_additional_message(
 
 
 async def test_collect_evidence_skipped_when_disabled(handler, mock_env_manager):
-    mock_env_manager.get_evidence.return_value = False
-    output_files = mock_env_manager.get_output_files.return_value
+    mock_env_manager.evidence = False
+    output_files = mock_env_manager.output_files
 
     await handler.collect_evidence("example.com", "dangling", output_files)
 
@@ -97,10 +97,10 @@ async def test_collect_evidence_skipped_when_disabled(handler, mock_env_manager)
 
 
 async def test_collect_evidence_called_per_nameserver(handler, mock_env_manager):
-    mock_env_manager.get_evidence.return_value = True
-    mock_env_manager.get_resolvers.return_value = ["8.8.8.8", "1.1.1.1"]
+    mock_env_manager.evidence = True
+    mock_env_manager.nameservers = ["8.8.8.8", "1.1.1.1"]
     handler.evidence_collector.perform_dns_evidence = AsyncMock()
-    output_files = mock_env_manager.get_output_files.return_value
+    output_files = mock_env_manager.output_files
 
     await handler.collect_evidence("example.com", "dangling", output_files)
 

--- a/tests/test_lambda_environment_manager.py
+++ b/tests/test_lambda_environment_manager.py
@@ -99,7 +99,7 @@ def test_logger_has_stream_handler(tmp_path):
 
 def test_output_files_created(tmp_path):
     mgr = _make_manager(tmp_path)
-    output_files = mgr.get_output_files()
+    output_files = mgr.output_files
     assert "standard" in output_files
     for key, path in output_files["standard"].items():
         if key != "environment":  # JSON written separately

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -33,12 +33,11 @@ def mock_s3(tmp_path):
 @pytest.fixture
 def mock_env_manager(tmp_path):
     mgr = MagicMock()
-    mgr.get_output_dir.return_value = str(tmp_path / "output")
+    mgr.output_dir = str(tmp_path / "output")
     mgr.extreme = False
     mgr.max_threads = 50
     mgr.domains = {"example.com"}
-    mgr.get_retries.return_value = 0
-    mgr.get_extreme.return_value = False
+    mgr.retries = 0
     os.makedirs(str(tmp_path / "output"), exist_ok=True)
     return mgr
 


### PR DESCRIPTION
## Summary

Splits the 660-line `EnvironmentManager` god class into three focused units, closing #41.

| Class | Lines | Responsibility |
|-------|-------|---------------|
| `ConfigResolver` | ~128 | argparse setup, validation, config.json merge |
| `OutputManager` | ~65 | output directory/file creation, async `write_to_file` |
| `EnvironmentManager` | ~162 | thin orchestrator — logging, env metadata, domain I/O |

**Before:** 660 lines, 7 `LambdaEnvironmentManager` overrides, ~20 trivial Java-style getters
**After:** 162 lines, 1 `LambdaEnvironmentManager` override (`log_effective_configuration`), zero trivial getters

## What changed

- `classes/config_resolver.py` — new; owns all argparse + config.json logic
- `classes/output_manager.py` — new; owns file/directory creation and async writes
- `classes/environment_manager.py` — slimmed to ≤ 200 lines; imports the two above
- `classes/lambda_environment_manager.py` — now uses `OutputManager` directly; overrides reduced from 7 → 1
- All callers updated: `get_output_files()` → `.output_files`, `get_retries()` → `.retries`, etc.
- Test mock in `conftest.py` updated to direct attribute assignment (no more `.return_value` on trivial getters)

## Acceptance criteria (from issue)

- [x] `EnvironmentManager` is ≤ 200 lines (162)
- [x] Java-style getters replaced with direct attribute access
- [x] `LambdaEnvironmentManager` overrides are minimal (≤ 2 methods) — now 1
- [x] All 138 existing tests pass
- [x] `flake8 .` exits 0

## Test plan

- [x] `pytest tests/ -q` — 138 passed
- [x] `flake8 .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)