### PR TITLE
Bump black >=26.3.1 (CVE-2026-32274)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Development tooling — not needed at runtime or in Lambda
 -r requirements.txt
-black~=24.0
+black>=26.3.1
 isort~=5.13
 flake8~=7.0
 pre-commit~=3.7


### PR DESCRIPTION
## Summary
- Bumps `black` from `~=24.0` to `>=26.3.1` in `requirements-dev.txt`
- Fixes Dependabot high-severity alert: **GHSA-3936-cmfr-pm3m / CVE-2026-32274**
  - Path traversal via unsanitised `--python-cell-magics` value written into the Black cache filename
  - Fixed upstream in Black 26.3.1

## Test plan
- [ ] `pip install -r requirements-dev.txt` resolves without conflict
- [ ] `black --check .` passes (formatting unchanged)
- [ ] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)