### PR TITLE
Add end-of-run summary with prominent takeover candidate reporting (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,9 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#36](https://github.com/incendiary/DNSResolver/issues/36) | ✅ v1.1.1 | Progress bar stability — log output routed through `tqdm.write()` |
 | [#37](https://github.com/incendiary/DNSResolver/issues/37) | ✅ v1.2.0 | AWS Lambda / S3 support — `lambda_handler.py` entrypoint with S3 I/O |
 | [#42](https://github.com/incendiary/DNSResolver/issues/42) | ✅ v1.2.1 | Enforce code style with Black, isort, flake8, and pre-commit hooks |
-| [#41](https://github.com/incendiary/DNSResolver/issues/41) | 🔄 v1.3.0 | Refactor `EnvironmentManager` — `ConfigResolver` + `OutputManager` split; trivial getters replaced with direct attribute access (PR open) |
-| [#43](https://github.com/incendiary/DNSResolver/issues/43) | 🔲 planned | Refactor `DNSHandler` — split resolution, takeover detection, and categorisation into focused classes |
+| [#41](https://github.com/incendiary/DNSResolver/issues/41) | ✅ v1.3.0 | Refactor `EnvironmentManager` — `ConfigResolver` + `OutputManager` split; trivial getters replaced with direct attribute access |
+| [#43](https://github.com/incendiary/DNSResolver/issues/43) | 🔄 v1.3.0 | Refactor `DNSHandler` — split resolution, takeover detection, and categorisation into focused classes (PR open) |
+| [#48](https://github.com/incendiary/DNSResolver/issues/48) | 🔄 v1.4.0 | End-of-run summary — at-a-glance verdict with prominently flagged takeover candidates (PR open) |
 
 ## Contributing
 

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -4,14 +4,16 @@ class RunSummary:
         self._output_dir = output_dir
 
     def _lines(self, key):
-        path = self._files.get(key, "")
+        path = self._files.get(key)
+        if not path:
+            return []
         try:
             with open(path, encoding="utf-8") as f:
                 return [ln.strip() for ln in f if ln.strip()]
         except OSError:
             return []
 
-    def print(self, total_input, failed_count):
+    def display(self, total_input, failed_count):
         resolved_count = len(self._lines("resolved"))
         unresolved_count = len(self._lines("unresolved"))
         dangling = self._lines("dangling")
@@ -26,12 +28,14 @@ class RunSummary:
             if len(parts) >= 5:
                 orig, current, category, recommendation, evidence = parts[:5]
                 by_category.setdefault(category, []).append(
-                    (orig, current, recommendation, evidence)
+                    (current, recommendation, evidence)
                 )
+
+        dangling_count = sum(len(v) for v in by_category.values())
+        total_candidates = dangling_count + len(ns_takeover)
 
         bar = "=" * 64
         thin = "-" * 64
-        total_candidates = len(dangling) + len(ns_takeover)
 
         print(f"\n{bar}")
         print("  DNSResolver — Run Summary")
@@ -51,14 +55,13 @@ class RunSummary:
         else:
             print(f"  [!] {total_candidates} TAKEOVER CANDIDATE(S) DETECTED [!]")
 
-            if dangling:
+            if dangling_count:
                 print()
-                print(f"  Dangling CNAMEs ({len(dangling)})")
+                print(f"  Dangling CNAMEs ({dangling_count})")
                 for category, entries in sorted(by_category.items()):
                     print(f"    [{category}]")
-                    for orig, current, rec, evidence in entries:
-                        label = current if current != orig else orig
-                        print(f"      {label}")
+                    for current, rec, evidence in entries:
+                        print(f"      {current}")
                         print(f"        Recommendation : {rec}")
                         print(f"        Evidence       : {evidence}")
 

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -1,0 +1,75 @@
+class RunSummary:
+    def __init__(self, output_files, output_dir):
+        self._files = output_files["standard"]
+        self._output_dir = output_dir
+
+    def _lines(self, key):
+        path = self._files.get(key, "")
+        try:
+            with open(path, encoding="utf-8") as f:
+                return [ln.strip() for ln in f if ln.strip()]
+        except OSError:
+            return []
+
+    def print(self, total_input, failed_count):
+        resolved_count = len(self._lines("resolved"))
+        unresolved_count = len(self._lines("unresolved"))
+        dangling = self._lines("dangling")
+        ns_takeover = self._lines("ns_takeover")
+        aws_count = len(self._lines("aws"))
+        gcp_count = len(self._lines("gcp"))
+        azure_count = len(self._lines("azure"))
+
+        by_category = {}
+        for line in dangling:
+            parts = line.split("|")
+            if len(parts) >= 5:
+                orig, current, category, recommendation, evidence = parts[:5]
+                by_category.setdefault(category, []).append(
+                    (orig, current, recommendation, evidence)
+                )
+
+        bar = "=" * 64
+        thin = "-" * 64
+        total_candidates = len(dangling) + len(ns_takeover)
+
+        print(f"\n{bar}")
+        print("  DNSResolver — Run Summary")
+        print(bar)
+        print(f"  Input domains        : {total_input:>6,}")
+        print(f"  Resolved             : {resolved_count:>6,}")
+        print(f"  Unresolved errors    : {unresolved_count:>6,}")
+        print(f"  Failed (all retries) : {failed_count:>6,}")
+        print()
+        print(
+            f"  CSP matches — AWS: {aws_count}  GCP: {gcp_count}  Azure: {azure_count}"
+        )
+        print(thin)
+
+        if total_candidates == 0:
+            print("  No takeover candidates detected.")
+        else:
+            print(f"  [!] {total_candidates} TAKEOVER CANDIDATE(S) DETECTED [!]")
+
+            if dangling:
+                print()
+                print(f"  Dangling CNAMEs ({len(dangling)})")
+                for category, entries in sorted(by_category.items()):
+                    print(f"    [{category}]")
+                    for orig, current, rec, evidence in entries:
+                        label = current if current != orig else orig
+                        print(f"      {label}")
+                        print(f"        Recommendation : {rec}")
+                        print(f"        Evidence       : {evidence}")
+
+            if ns_takeover:
+                print()
+                print(f"  NS Takeover candidates ({len(ns_takeover)})")
+                for line in ns_takeover:
+                    parts = line.split("|")
+                    if len(parts) >= 2:
+                        print(f"    {parts[0]} -> NS: {parts[1]}")
+
+        print(thin)
+        print(f"  Output : {self._output_dir}")
+        print(f"{bar}\n")

--- a/resolver.py
+++ b/resolver.py
@@ -39,7 +39,6 @@ async def run(env_manager):
     retries = env_manager.retries
     dns_handler = DNSHandler(env_manager)
     sem = asyncio.Semaphore(env_manager.max_threads or 50)
-    all_dangling_domains: set = set()
 
     async def bounded_process(domain, pbar):
         async with sem:
@@ -66,8 +65,7 @@ async def run(env_manager):
                 )
                 failed.append(domain)
                 continue
-            success, _final_ips, dangling = result
-            all_dangling_domains.update(dangling)
+            success, _final_ips, _dangling = result
             if not success:
                 failed.append(domain)
         domains_to_process = failed
@@ -86,7 +84,7 @@ async def run(env_manager):
             retries + 1,
         )
 
-    RunSummary(env_manager.output_files, env_manager.output_dir).print(
+    RunSummary(env_manager.output_files, env_manager.output_dir).display(
         len(env_manager.domains), len(domains_to_process)
     )
 

--- a/resolver.py
+++ b/resolver.py
@@ -10,6 +10,7 @@ from imports.cloud_ip_ranges import (
     fetch_azure_ip_ranges,
     fetch_google_cloud_ip_ranges,
 )
+from classes.run_summary import RunSummary
 from imports.domain_processor import process_domain_async
 
 
@@ -85,15 +86,8 @@ async def run(env_manager):
             retries + 1,
         )
 
-    if all_dangling_domains:
-        env_manager.log_info(
-            "%d dangling domain(s) detected: %s",
-            len(all_dangling_domains),
-            ", ".join(sorted(all_dangling_domains)),
-        )
-
-    env_manager.log_info(
-        "All resolutions completed. Results saved to %s", env_manager.output_dir
+    RunSummary(env_manager.output_files, env_manager.output_dir).print(
+        len(env_manager.domains), len(domains_to_process)
     )
 
     if env_manager.extreme:

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -1,0 +1,160 @@
+"""Tests for RunSummary — verifies stdout output using capsys and tmp_path."""
+
+import pytest
+
+from classes.run_summary import RunSummary
+
+
+def _make_summary(tmp_path, files=None):
+    """Build a RunSummary backed by real temp files populated with given lines."""
+    standard = {
+        "resolved": tmp_path / "resolved.txt",
+        "unresolved": tmp_path / "unresolved.txt",
+        "dangling": tmp_path / "dangling.txt",
+        "ns_takeover": tmp_path / "ns_takeover.txt",
+        "aws": tmp_path / "aws.txt",
+        "gcp": tmp_path / "gcp.txt",
+        "azure": tmp_path / "azure.txt",
+    }
+    for key, path in standard.items():
+        content = files.get(key, "") if files else ""
+        path.write_text(content, encoding="utf-8")
+
+    output_files = {"standard": {k: str(v) for k, v in standard.items()}}
+    return RunSummary(output_files, str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Clean run — no candidates
+# ---------------------------------------------------------------------------
+
+
+def test_no_candidates_prints_clean_message(tmp_path, capsys):
+    summary = _make_summary(
+        tmp_path,
+        {
+            "resolved": "example.com|1.2.3.4\nfoo.com|5.6.7.8\n",
+        },
+    )
+    summary.print(total_input=2, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "No takeover candidates detected." in out
+    assert "[!]" not in out
+
+
+def test_counts_are_accurate(tmp_path, capsys):
+    summary = _make_summary(
+        tmp_path,
+        {
+            "resolved": "a.com|1.1.1.1\nb.com|2.2.2.2\n",
+            "unresolved": "DNS resolution error for c.com: timeout\n",
+            "aws": "a.com|1.1.1.1\n",
+            "gcp": "b.com|2.2.2.2\nb2.com|3.3.3.3\n",
+        },
+    )
+    summary.print(total_input=5, failed_count=1)
+
+    out = capsys.readouterr().out
+    assert "5" in out  # total input
+    assert "AWS: 1" in out
+    assert "GCP: 2" in out
+    assert "Azure: 0" in out
+
+
+# ---------------------------------------------------------------------------
+# Dangling CNAMEs
+# ---------------------------------------------------------------------------
+
+
+def test_dangling_cname_flagged(tmp_path, capsys):
+    dangling = "root.example.com|app.s3.amazonaws.com|aws_s3|Remove the CNAME|https://evidence.link\n"
+    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary.print(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "[!]" in out
+    assert "TAKEOVER CANDIDATE" in out
+    assert "Dangling CNAMEs (1)" in out
+    assert "[aws_s3]" in out
+    assert "app.s3.amazonaws.com" in out
+    assert "Remove the CNAME" in out
+    assert "https://evidence.link" in out
+
+
+def test_dangling_cnames_grouped_by_category(tmp_path, capsys):
+    dangling = (
+        "a.com|a.herokudns.com|heroku|Remove it|https://heroku.example\n"
+        "b.com|b.herokudns.com|heroku|Remove it|https://heroku.example\n"
+        "c.com|c.s3.amazonaws.com|aws_s3|Remove the CNAME|https://aws.example\n"
+    )
+    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary.print(total_input=3, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "Dangling CNAMEs (3)" in out
+    # aws_s3 sorts before heroku alphabetically
+    aws_pos = out.index("[aws_s3]")
+    heroku_pos = out.index("[heroku]")
+    assert aws_pos < heroku_pos
+
+
+def test_dangling_line_missing_fields_skipped_gracefully(tmp_path, capsys):
+    """A malformed dangling line (< 5 fields) should not crash the summary."""
+    summary = _make_summary(tmp_path, {"dangling": "only|two\n"})
+    summary.print(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    # The line is silently skipped; candidate block still shown but empty category
+    assert "Dangling CNAMEs (1)" in out
+
+
+# ---------------------------------------------------------------------------
+# NS takeover
+# ---------------------------------------------------------------------------
+
+
+def test_ns_takeover_flagged(tmp_path, capsys):
+    ns = "vuln.example.com|ns1.orphaned-registrar.com\n"
+    summary = _make_summary(tmp_path, {"ns_takeover": ns})
+    summary.print(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "[!]" in out
+    assert "NS Takeover candidates (1)" in out
+    assert "vuln.example.com -> NS: ns1.orphaned-registrar.com" in out
+
+
+def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):
+    dangling = "a.com|a.herokudns.com|heroku|Remove|https://h.example\n"
+    ns = "b.com|ns1.dead.example\nc.com|ns2.dead.example\n"
+    summary = _make_summary(tmp_path, {"dangling": dangling, "ns_takeover": ns})
+    summary.print(total_input=3, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "3 TAKEOVER CANDIDATE(S)" in out
+
+
+# ---------------------------------------------------------------------------
+# Resilience
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_treated_as_empty(tmp_path, capsys):
+    """If an output file is absent, _lines() returns [] without crashing."""
+    output_files = {
+        "standard": {
+            "resolved": "/nonexistent/resolved.txt",
+            "unresolved": "/nonexistent/unresolved.txt",
+            "dangling": "/nonexistent/dangling.txt",
+            "ns_takeover": "/nonexistent/ns_takeover.txt",
+            "aws": "/nonexistent/aws.txt",
+            "gcp": "/nonexistent/gcp.txt",
+            "azure": "/nonexistent/azure.txt",
+        }
+    }
+    summary = RunSummary(output_files, "/tmp/output")
+    summary.print(total_input=0, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "No takeover candidates detected." in out

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -36,7 +36,7 @@ def test_no_candidates_prints_clean_message(tmp_path, capsys):
             "resolved": "example.com|1.2.3.4\nfoo.com|5.6.7.8\n",
         },
     )
-    summary.print(total_input=2, failed_count=0)
+    summary.display(total_input=2, failed_count=0)
 
     out = capsys.readouterr().out
     assert "No takeover candidates detected." in out
@@ -53,7 +53,7 @@ def test_counts_are_accurate(tmp_path, capsys):
             "gcp": "b.com|2.2.2.2\nb2.com|3.3.3.3\n",
         },
     )
-    summary.print(total_input=5, failed_count=1)
+    summary.display(total_input=5, failed_count=1)
 
     out = capsys.readouterr().out
     assert "5" in out  # total input
@@ -70,7 +70,7 @@ def test_counts_are_accurate(tmp_path, capsys):
 def test_dangling_cname_flagged(tmp_path, capsys):
     dangling = "root.example.com|app.s3.amazonaws.com|aws_s3|Remove the CNAME|https://evidence.link\n"
     summary = _make_summary(tmp_path, {"dangling": dangling})
-    summary.print(total_input=1, failed_count=0)
+    summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
     assert "[!]" in out
@@ -89,7 +89,7 @@ def test_dangling_cnames_grouped_by_category(tmp_path, capsys):
         "c.com|c.s3.amazonaws.com|aws_s3|Remove the CNAME|https://aws.example\n"
     )
     summary = _make_summary(tmp_path, {"dangling": dangling})
-    summary.print(total_input=3, failed_count=0)
+    summary.display(total_input=3, failed_count=0)
 
     out = capsys.readouterr().out
     assert "Dangling CNAMEs (3)" in out
@@ -100,13 +100,12 @@ def test_dangling_cnames_grouped_by_category(tmp_path, capsys):
 
 
 def test_dangling_line_missing_fields_skipped_gracefully(tmp_path, capsys):
-    """A malformed dangling line (< 5 fields) should not crash the summary."""
+    """A malformed dangling line (< 5 fields) should not crash and is silently ignored."""
     summary = _make_summary(tmp_path, {"dangling": "only|two\n"})
-    summary.print(total_input=1, failed_count=0)
+    summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
-    # The line is silently skipped; candidate block still shown but empty category
-    assert "Dangling CNAMEs (1)" in out
+    assert "No takeover candidates detected." in out
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +116,7 @@ def test_dangling_line_missing_fields_skipped_gracefully(tmp_path, capsys):
 def test_ns_takeover_flagged(tmp_path, capsys):
     ns = "vuln.example.com|ns1.orphaned-registrar.com\n"
     summary = _make_summary(tmp_path, {"ns_takeover": ns})
-    summary.print(total_input=1, failed_count=0)
+    summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
     assert "[!]" in out
@@ -129,7 +128,7 @@ def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):
     dangling = "a.com|a.herokudns.com|heroku|Remove|https://h.example\n"
     ns = "b.com|ns1.dead.example\nc.com|ns2.dead.example\n"
     summary = _make_summary(tmp_path, {"dangling": dangling, "ns_takeover": ns})
-    summary.print(total_input=3, failed_count=0)
+    summary.display(total_input=3, failed_count=0)
 
     out = capsys.readouterr().out
     assert "3 TAKEOVER CANDIDATE(S)" in out
@@ -154,7 +153,7 @@ def test_missing_file_treated_as_empty(tmp_path, capsys):
         }
     }
     summary = RunSummary(output_files, "/tmp/output")
-    summary.print(total_input=0, failed_count=0)
+    summary.display(total_input=0, failed_count=0)
 
     out = capsys.readouterr().out
     assert "No takeover candidates detected." in out


### PR DESCRIPTION
Closes #48

## Summary
- Adds `classes/run_summary.py` — `RunSummary` reads the five output files after all domains are processed and prints a structured terminal summary
- Zero takeover candidates → single clean confirmation line
- Any dangling CNAMEs or NS-takeover hits → `[!] N TAKEOVER CANDIDATE(S) DETECTED [!]` block, dangling entries grouped by service category with recommendation and evidence link per entry
- Wired into `resolver.run()` so both the CLI and Lambda paths get the summary automatically
- README roadmap updated: #41 marked complete, #43 and #48 shown as in-progress

## Example output — candidates found
```
================================================================
  DNSResolver — Run Summary
================================================================
  Input domains        :  1,000
  Resolved             :    987
  Unresolved errors    :      8
  Failed (all retries) :      5

  CSP matches — AWS: 43  GCP: 12  Azure: 7
----------------------------------------------------------------
  [!] 3 TAKEOVER CANDIDATE(S) DETECTED [!]

  Dangling CNAMEs (2)
    [aws_s3]
      app.example.com
        Recommendation : Remove the CNAME record
        Evidence       : https://...

  NS Takeover candidates (1)
    vuln.example.com -> NS: ns1.dead-registrar.com
----------------------------------------------------------------
  Output : output/20260509_143022/
================================================================
```

## Test plan
- [x] 8 unit tests — `pytest tests/test_run_summary.py` all pass
- [x] Full suite: 146 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)