### PR TITLE
Expand domain categorisation patterns (#54)

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,267 +3,307 @@
         "output_dir": "output",
         "max_threads": 2,
         "timeout": 1,
-	    "nameservers": "1.1.1.1,8.8.8.8",
+        "nameservers": "1.1.1.1,8.8.8.8",
         "verbose": false,
         "retries": 2,
         "evidence": true,
         "extreme": false
     },
-    "domain_categorization": {
+    "domain_categorisation": {
+        "acquia": {
+            "regex": "\\.acquia\\.com\\.",
+            "recommendation": "Delete the CNAME record — the Acquia site no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz"
+        },
+        "akamai": {
+            "regex": "\\.akamai\\.net\\.|\\.akamaihd\\.net\\.",
+            "recommendation": "Remove the CNAME record if the Akamai property is no longer active",
+            "evidence": "https://www.akamai.com/us/en/resources/faq.jsp"
+        },
+        "algolia": {
+            "regex": "\\.algolia\\.net\\.|\\.algolianet\\.com\\.",
+            "recommendation": "Remove the CNAME if the Algolia index no longer exists",
+            "evidence": "https://www.algolia.com/doc/"
+        },
+        "amazon_ses": {
+            "regex": "\\.dkim\\.amazonses\\.com\\.",
+            "recommendation": "Remove the DKIM CNAME if SES sending is no longer configured",
+            "evidence": "https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim.html"
+        },
+        "api_gateway": {
+            "regex": "\\.execute-api\\.amazonaws\\.com\\.",
+            "recommendation": "Delete the CNAME — the API Gateway stage has been removed",
+            "evidence": "https://docs.aws.amazon.com/apigateway/latest/developerguide/"
+        },
         "aws_acm": {
             "regex": "\\.acm-validations\\.aws\\.",
-            "recommendation": "Do not remove",
-            "evidence": "https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html#cnames-overview"
+            "recommendation": "Do not remove — this record validates an ACM certificate",
+            "evidence": "https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html"
+        },
+        "aws_amplify": {
+            "regex": "\\.amplifyapp\\.com\\.",
+            "recommendation": "Delete the CNAME — the Amplify app or branch no longer exists",
+            "evidence": "https://docs.amplify.aws"
+        },
+        "aws_elastic_beanstalk": {
+            "regex": "\\.elasticbeanstalk\\.com\\.",
+            "recommendation": "Delete the CNAME — the Elastic Beanstalk environment has been terminated; the subdomain may be reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/97"
+        },
+        "aws_s3": {
+            "regex": "\\.s3\\.amazonaws\\.com\\.|\\.s3-website[.-][a-z0-9-]+\\.amazonaws\\.com\\.|\\.s3\\.dualstack\\.[a-z0-9-]+\\.amazonaws\\.com\\.",
+            "recommendation": "Delete the CNAME or recreate the S3 bucket — unclaimed buckets can be registered by anyone in the same region",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/36"
+        },
+        "azure": {
+            "regex": "\\.azurewebsites\\.net\\.|\\.blob\\.core\\.windows\\.net\\.|\\.table\\.core\\.windows\\.net\\.|\\.queue\\.core\\.windows\\.net\\.|\\.database\\.windows\\.net\\.|\\.azureedge\\.net\\.|\\.azure-api\\.net\\.|\\.microsoftonline\\.com\\.|\\.trafficmanager\\.net\\.",
+            "recommendation": "Delete the CNAME — the Azure resource has been removed; dangling Azure records are exploitable",
+            "evidence": "https://docs.microsoft.com/en-us/azure/security/fundamentals/subdomain-takeover"
+        },
+        "bitbucket": {
+            "regex": "\\.bitbucket\\.io\\.|\\.bitbucket\\.org\\.",
+            "recommendation": "Delete the CNAME — the Bitbucket Pages site no longer exists",
+            "evidence": "https://support.atlassian.com/bitbucket-cloud/docs/"
+        },
+        "box": {
+            "regex": "\\.box\\.com\\.",
+            "recommendation": "Remove the CNAME if the Box embed is no longer active",
+            "evidence": "https://support.box.com"
+        },
+        "cloud_functions": {
+            "regex": "\\.cloudfunctions\\.net\\.",
+            "recommendation": "Delete the CNAME — the Cloud Function no longer exists",
+            "evidence": "https://cloud.google.com/functions/docs"
+        },
+        "cloudflare": {
+            "regex": "\\.cloudflare\\.com\\.|\\.cf\\.cloudflare\\.com\\.|\\.cloudflare-dns\\.com\\.",
+            "recommendation": "Remove the CNAME — the Cloudflare zone or page rule is no longer configured",
+            "evidence": "https://developers.cloudflare.com"
+        },
+        "cloudflare_ips": {
+            "regex": "\\.cf\\.cloudflareresolve\\.com\\.|\\.cloudflareresolve\\.com\\.",
+            "recommendation": "Remove the CNAME if the Cloudflare routing is no longer active",
+            "evidence": "https://developers.cloudflare.com"
         },
         "cloudfront": {
             "regex": "\\.cloudfront\\.net\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Delete the CNAME — the CloudFront distribution has been removed",
             "evidence": "https://aws.amazon.com/premiumsupport/knowledge-center/delete-cloudfront-cname-entry/"
+        },
+        "datadog": {
+            "regex": "\\.datadoghq\\.com\\.",
+            "recommendation": "Remove the CNAME if the Datadog custom domain is no longer mapped",
+            "evidence": "https://docs.datadoghq.com"
+        },
+        "digitalocean": {
+            "regex": "\\.digitaloceanspaces\\.com\\.|\\.do\\.digitaloceanspaces\\.com\\.",
+            "recommendation": "Delete the CNAME or recreate the Space — unclaimed Spaces are reclaimable",
+            "evidence": "https://www.digitalocean.com/docs/spaces/"
+        },
+        "docusign": {
+            "regex": "\\.docusign\\.net\\.",
+            "recommendation": "Remove the CNAME if DocuSign sending is no longer configured",
+            "evidence": "https://support.docusign.com"
+        },
+        "dropbox": {
+            "regex": "\\.dropboxusercontent\\.com\\.|\\.dropbox\\.com\\.",
+            "recommendation": "Remove the CNAME if the Dropbox share is no longer active",
+            "evidence": "https://help.dropbox.com"
+        },
+        "dyn": {
+            "regex": "\\.dynect\\.net\\.|\\.dyn\\.com\\.",
+            "recommendation": "Delete the CNAME — the Dyn DNS entry no longer resolves",
+            "evidence": "https://help.dyn.com"
+        },
+        "fastly": {
+            "regex": "\\.fastly\\.net\\.|\\.fastlylb\\.net\\.",
+            "recommendation": "Delete the CNAME — the Fastly service is no longer configured",
+            "evidence": "https://docs.fastly.com"
+        },
+        "firebase": {
+            "regex": "\\.firebaseio\\.com\\.|\\.firebasedatabase\\.app\\.",
+            "recommendation": "Delete the CNAME — the Firebase project or database no longer exists",
+            "evidence": "https://firebase.google.com/docs"
+        },
+        "fly_io": {
+            "regex": "\\.fly\\.dev\\.|\\.flycast\\.dev\\.",
+            "recommendation": "Delete the CNAME — the Fly.io app has been deleted; the name may be reclaimable",
+            "evidence": "https://fly.io/docs/networking/custom-domain/"
+        },
+        "ghost": {
+            "regex": "\\.ghost\\.io\\.",
+            "recommendation": "Delete the CNAME — the Ghost(Pro) blog no longer exists; the subdomain is reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/41"
+        },
+        "github": {
+            "regex": "\\.github\\.io\\.|\\.githubusercontent\\.com\\.",
+            "recommendation": "Delete the CNAME or recreate the GitHub Pages site — the username/org or repo no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/37"
+        },
+        "google": {
+            "regex": "\\.googlehosted\\.com\\.|\\.googledomains\\.com\\.|\\.googleapis\\.com\\.|\\.googleusercontent\\.com\\.|\\.gstatic\\.com\\.|\\.google\\.",
+            "recommendation": "Remove the CNAME if the Google-hosted resource no longer exists",
+            "evidence": "https://developers.google.com"
+        },
+        "heroku": {
+            "regex": "\\.herokudns\\.com\\.|\\.herokuapp\\.com\\.|\\.herokussl\\.com\\.",
+            "recommendation": "Delete the CNAME — the Heroku app no longer exists; the subdomain can be claimed by anyone",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/2"
+        },
+        "hubspot": {
+            "regex": "\\.hubspot\\.net\\.|\\.hs-sites\\.com\\.|\\.hubspotpagebuilder\\.com\\.",
+            "recommendation": "Delete the CNAME — the HubSpot portal or landing page no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/22"
+        },
+        "incapsula": {
+            "regex": "\\.incapdns\\.net\\.",
+            "recommendation": "Remove the CNAME if the Imperva/Incapsula site is no longer protected",
+            "evidence": "https://docs.imperva.com/bundle/cloud-application-security/page/more/faq/incapsula-nameserver.html"
+        },
+        "jira": {
+            "regex": "\\.jira\\.com\\.|\\.atlassian\\.net\\.",
+            "recommendation": "Remove the CNAME if the Atlassian product custom domain is no longer mapped",
+            "evidence": "https://support.atlassian.com/jira-cloud/"
+        },
+        "launchrock": {
+            "regex": "\\.launchrock\\.com\\.",
+            "recommendation": "Delete the CNAME — the Launchrock page no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz"
         },
         "microsoft": {
             "regex": "\\.onmicrosoft\\.com\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Remove the CNAME if the Microsoft 365 tenant is no longer active",
             "evidence": "https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/customize-tenant-name"
+        },
+        "netlify": {
+            "regex": "\\.netlify\\.com\\.|\\.netlify\\.app\\.|\\.netlifyglobalcdn\\.com\\.",
+            "recommendation": "Delete the CNAME — the Netlify site no longer exists; the subdomain may be reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/40"
+        },
+        "newrelic": {
+            "regex": "\\.newrelic\\.com\\.",
+            "recommendation": "Remove the CNAME if the New Relic custom domain is no longer mapped",
+            "evidence": "https://docs.newrelic.com"
+        },
+        "ngrok": {
+            "regex": "\\.ngrok\\.io\\.|\\.ngrok-free\\.app\\.",
+            "recommendation": "Delete the CNAME — the ngrok tunnel is no longer active",
+            "evidence": "https://ngrok.com/docs"
+        },
+        "oracle": {
+            "regex": "\\.oraclecloud\\.com\\.|\\.oracle\\.com\\.",
+            "recommendation": "Remove the CNAME if the Oracle Cloud resource no longer exists",
+            "evidence": "https://docs.oracle.com/en/cloud/"
+        },
+        "pantheon": {
+            "regex": "\\.pantheonsite\\.io\\.|\\.pantheon\\.io\\.",
+            "recommendation": "Delete the CNAME — the Pantheon environment no longer exists",
+            "evidence": "https://pantheon.io/docs"
+        },
+        "railway": {
+            "regex": "\\.railway\\.app\\.",
+            "recommendation": "Delete the CNAME — the Railway service has been deleted; the subdomain may be reclaimable",
+            "evidence": "https://docs.railway.app/deploy/custom-domains"
+        },
+        "readthedocs": {
+            "regex": "\\.readthedocs\\.io\\.|\\.readthedocs-hosted\\.com\\.",
+            "recommendation": "Delete the CNAME or reclaim the ReadTheDocs project — the documentation project name is reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/9"
+        },
+        "render": {
+            "regex": "\\.onrender\\.com\\.",
+            "recommendation": "Delete the CNAME — the Render service has been suspended or deleted",
+            "evidence": "https://render.com/docs/custom-domains"
         },
         "salesforce": {
             "regex": "\\.custdkim\\.salesforce\\.com\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Remove the DKIM CNAME if Salesforce sending is no longer configured",
             "evidence": "https://help.salesforce.com/articleView?id=000313497&type=1&mode=1"
         },
         "sendgrid": {
             "regex": "\\.sendgrid\\.net\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Remove the CNAME if SendGrid domain authentication is no longer active",
             "evidence": "https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/"
-        },
-        "amazon_ses": {
-            "regex": "\\.dkim\\.amazonses\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-authentication-dkim.html"
-        },
-        "digital_platforms": {
-            "regex": "bizportal\\.digital\\.singtel\\.com|clcf\\.singtelinsurance\\.com",
-            "recommendation": "Unclassified",
-            "evidence": "https://www.singtel.com"
-        },
-        "docusign": {
-            "regex": "\\.docusign\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.docusign.com/en/guides/DocuSign-Signing-Signing-FAQs"
-        },
-        "incapsula": {
-            "regex": "\\.incapdns\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.imperva.com/bundle/cloud-application-security/page/more/faq/incapsula-nameserver.html"
-        },
-        "google": {
-            "regex": "\\.googlehosted\\.com\\.|\\.googledomains\\.com\\.|\\.googleapis\\.com\\.|\\.googleusercontent\\.com\\.|\\.gstatic\\.com\\.|\\.google\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://developers.google.com"
-        },
-        "akamai": {
-            "regex": "\\.akamai\\.net\\.|\\.akamaihd\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://www.akamai.com/us/en/resources/faq.jsp"
-        },
-        "cloudflare": {
-            "regex": "\\.cloudflare\\.com\\.|\\.cf\\.cloudflare\\.com\\.|\\.cloudflare-dns\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://developers.cloudflare.com"
-        },
-        "vercel": {
-            "regex": "\\.vercel\\.app\\.|\\.now\\.sh\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://vercel.com/docs"
-        },
-        "heroku": {
-            "regex": "\\.herokuapp\\.com\\.|\\.herokussl\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://devcenter.heroku.com"
-        },
-        "fastly": {
-            "regex": "\\.fastly\\.net\\.|\\.fastlylb\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.fastly.com"
-        },
-        "netlify": {
-            "regex": "\\.netlify\\.com\\.|\\.netlifyglobalcdn\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.netlify.com"
-        },
-        "pantheon": {
-            "regex": "\\.pantheonsite\\.io\\.|\\.pantheon\\.io\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://pantheon.io/docs"
-        },
-        "github": {
-            "regex": "\\.github\\.io\\.|\\.githubusercontent\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.github.com"
-        },
-        "bitbucket": {
-            "regex": "\\.bitbucket\\.io\\.|\\.bitbucket\\.org\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.atlassian.com/bitbucket-cloud/docs/"
-        },
-        "digitalocean": {
-            "regex": "\\.digitaloceanspaces\\.com\\.|\\.do\\.digitaloceanspaces\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://www.digitalocean.com/docs/spaces/"
-        },
-        "azure": {
-            "regex": "\\.azurewebsites\\.net\\.|\\.blob\\.core\\.windows\\.net\\.|\\.table\\.core\\.windows\\.net\\.|\\.queue\\.core\\.windows\\.net\\.|\\.database\\.windows\\.net\\.|\\.azureedge\\.net\\.|\\.azure-api\\.net\\.|\\.microsoftonline\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.microsoft.com/en-us/azure/"
-        },
-        "dyn": {
-            "regex": "\\.dynect\\.net\\.|\\.dyn\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://help.dyn.com"
         },
         "shopify": {
             "regex": "\\.myshopify\\.com\\.|\\.shopify\\.com\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Delete the CNAME — the Shopify store is no longer active",
             "evidence": "https://help.shopify.com"
-        },
-        "wordpress": {
-            "regex": "\\.wordpress\\.com\\.|\\.wp\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://wordpress.org/support/"
-        },
-        "wix": {
-            "regex": "\\.wix\\.com\\.|\\.editorx\\.com\\.|\\.wixsite\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.wix.com"
-        },
-        "squarespace": {
-            "regex": "\\.squarespace\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.squarespace.com"
-        },
-        "weebly": {
-            "regex": "\\.weebly\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://www.weebly.com/app/help/us/en"
-        },
-        "zendesk": {
-            "regex": "\\.zendesk\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.zendesk.com"
-        },
-        "jira": {
-            "regex": "\\.jira\\.com\\.|\\.atlassian\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.atlassian.com/jira-cloud/"
-        },
-        "box": {
-            "regex": "\\.box\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.box.com"
-        },
-        "dropbox": {
-            "regex": "\\.dropboxusercontent\\.com\\.|\\.dropbox\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://help.dropbox.com"
         },
         "slack": {
             "regex": "\\.slack\\.com\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Remove the CNAME if the Slack workspace custom domain is no longer mapped",
             "evidence": "https://slack.com/help"
         },
-        "trello": {
-            "regex": "\\.trello\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://help.trello.com"
+        "squarespace": {
+            "regex": "\\.squarespace\\.com\\.",
+            "recommendation": "Delete the CNAME — the Squarespace site no longer exists",
+            "evidence": "https://support.squarespace.com"
         },
-        "zoom": {
-            "regex": "\\.zoom\\.us\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.zoom.us"
-        },
-        "algolia": {
-            "regex": "\\.algolia\\.net\\.|\\.algolianet\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://www.algolia.com/doc/"
-        },
-        "firebase": {
-            "regex": "\\.firebaseio\\.com\\.|\\.firebasedatabase\\.app\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://firebase.google.com/docs"
-        },
-        "cloudflare_ips": {
-            "regex": "\\.cf\\.cloudflareresolve\\.com\\.|\\.cloudflareresolve\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://developers.cloudflare.com"
-        },
-        "datadog": {
-            "regex": "\\.datadoghq\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.datadoghq.com"
-        },
-        "newrelic": {
-            "regex": "\\.newrelic\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.newrelic.com"
-        },
-        "heroku_legacy": {
-            "regex": "\\.herokudns\\.com\\.|\\.herokussl\\.com\\.|\\.herokuapp\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://devcenter.heroku.com"
-        },
-        "oracle": {
-            "regex": "\\.oraclecloud\\.com\\.|\\.oracle\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.oracle.com/en/cloud/"
-        },
-        "cloud_functions": {
-            "regex": "\\.cloudfunctions\\.net\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://cloud.google.com/functions/docs"
-        },
-        "strikingly": {
-            "regex": "\\.strikingly\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.strikingly.com"
-        },
-        "unbounce": {
-            "regex": "\\.unbouncepages\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://documentation.unbounce.com"
-        },
-        "launchrock": {
-            "regex": "\\.launchrock\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://support.launchrock.com"
-        },
-        "acquia": {
-            "regex": "\\.acquia\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.acquia.com"
-        },
-        "ngrok": {
-            "regex": "\\.ngrok\\.io\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://ngrok.com/docs"
+        "statuspage": {
+            "regex": "\\.statuspage\\.io\\.",
+            "recommendation": "Delete the CNAME — the Statuspage page no longer exists; the subdomain may be reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/11"
         },
         "strapi": {
             "regex": "\\.strapi\\.io\\.",
-            "recommendation": "Remove if dangling",
+            "recommendation": "Delete the CNAME — the Strapi Cloud project no longer exists",
             "evidence": "https://strapi.io/documentation"
         },
-        "netlify_edge": {
-            "regex": "\\.netlifyglobalcdn\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.netlify.com"
+        "strikingly": {
+            "regex": "\\.strikingly\\.com\\.",
+            "recommendation": "Delete the CNAME — the Strikingly site no longer exists",
+            "evidence": "https://support.strikingly.com"
         },
-        "aws_amplify": {
-            "regex": "\\.amplifyapp\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.amplify.aws"
+        "surge": {
+            "regex": "\\.surge\\.sh\\.",
+            "recommendation": "Delete the CNAME or republish to the same subdomain — unclaimed Surge projects are immediately reclaimable",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/1"
         },
-        "api_gateway": {
-            "regex": "\\.execute-api\\.amazonaws\\.com\\.",
-            "recommendation": "Remove if dangling",
-            "evidence": "https://docs.aws.amazon.com/apigateway/latest/developerguide/"
+        "trello": {
+            "regex": "\\.trello\\.com\\.",
+            "recommendation": "Remove the CNAME if the Trello board custom domain is no longer mapped",
+            "evidence": "https://help.trello.com"
+        },
+        "tumblr": {
+            "regex": "\\.tumblr\\.com\\.",
+            "recommendation": "Delete the CNAME — the Tumblr blog no longer exists; the custom domain can be reclaimed",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/12"
+        },
+        "unbounce": {
+            "regex": "\\.unbouncepages\\.com\\.",
+            "recommendation": "Delete the CNAME — the Unbounce landing page no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/26"
+        },
+        "vercel": {
+            "regex": "\\.vercel\\.app\\.|\\.now\\.sh\\.",
+            "recommendation": "Delete the CNAME — the Vercel project or deployment no longer exists",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/93"
+        },
+        "weebly": {
+            "regex": "\\.weebly\\.com\\.",
+            "recommendation": "Delete the CNAME — the Weebly site no longer exists",
+            "evidence": "https://www.weebly.com/app/help/us/en"
+        },
+        "wix": {
+            "regex": "\\.wix\\.com\\.|\\.editorx\\.com\\.|\\.wixsite\\.com\\.",
+            "recommendation": "Delete the CNAME — the Wix site no longer exists",
+            "evidence": "https://support.wix.com"
+        },
+        "wordpress": {
+            "regex": "\\.wordpress\\.com\\.|\\.wp\\.com\\.",
+            "recommendation": "Delete the CNAME — the WordPress.com site no longer exists",
+            "evidence": "https://wordpress.org/support/"
+        },
+        "zendesk": {
+            "regex": "\\.zendesk\\.com\\.",
+            "recommendation": "Delete the CNAME — the Zendesk Help Centre custom domain is no longer mapped",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/23"
+        },
+        "zoom": {
+            "regex": "\\.zoom\\.us\\.",
+            "recommendation": "Remove the CNAME if the Zoom vanity URL is no longer active",
+            "evidence": "https://support.zoom.us"
         }
     }
 }

--- a/config.json
+++ b/config.json
@@ -156,7 +156,7 @@
             "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/22"
         },
         "incapsula": {
-            "regex": "\\.incapdns\\.net\\.",
+            "regex": "\\.incapdns\\.net\\.|\\.impervadns\\.net\\.",
             "recommendation": "Remove the CNAME if the Imperva/Incapsula site is no longer protected",
             "evidence": "https://docs.imperva.com/bundle/cloud-application-security/page/more/faq/incapsula-nameserver.html"
         },


### PR DESCRIPTION
## Summary

- **Fixes silent production bug**: renames config key from `domain_categorization` → `domain_categorisation` to match the spelling used in `environment_manager.py`; patterns have never loaded since the initial commit — every dangling CNAME has been classified as `unknown`
- Removes proprietary `digital_platforms` entry (Singtel-specific hostnames)
- Removes `heroku_legacy` and `netlify_edge` duplicates; consolidates regex coverage into `heroku` and `netlify`
- Extends `azure` pattern to include `trafficmanager.net`
- Extends `incapsula` pattern to include `impervadns.net` (Imperva uses both hostnames)
- Adds 11 new high-value takeover targets: `aws_s3`, `aws_elastic_beanstalk`, `surge`, `ghost`, `tumblr`, `hubspot`, `statuspage`, `fly_io`, `render`, `railway`, `readthedocs`
- Updates all recommendation text to be actionable; evidence links point to specific EdOverflow/can-i-take-over-xyz issues where confirmed
- Sorts entries alphabetically

## Test plan

- [ ] `pytest -q` passes (139 tests)
- [ ] Re-run against a domain list — classified entries now appear in full in the summary instead of being collapsed into the unclassified count

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)