### PR TITLE
Fix CNAME target trailing-dot normalisation — patterns never matched in production

### DIFF
--- a/classes/takeover_detector.py
+++ b/classes/takeover_detector.py
@@ -92,6 +92,8 @@ class TakeoverDetector:
             if cname_answer:
                 self.env_manager.log_info(f"Domain {current_domain} is a CNAME record.")
                 target = cname_answer.cname
+                if not target.endswith("."):
+                    target += "."
                 self.env_manager.log_info(f"CNAME target: {target}")
                 if await self.check_dangling_cname_async(domain_context, target):
                     return True

--- a/tests/test_dns_handler_resolution.py
+++ b/tests/test_dns_handler_resolution.py
@@ -158,6 +158,28 @@ async def test_cname_chain_dangling_returns_true(handler, domain_context):
     assert result is True
 
 
+async def test_cname_target_without_trailing_dot_is_normalised(handler, domain_context):
+    """aiodns returns CNAME targets without trailing dot; the normalisation must add one
+    so that regex patterns ending with \\. match correctly."""
+    received_targets = []
+    cname_result = MagicMock()
+    cname_result.cname = "gbe8q5o.impervadns.net"  # no trailing dot — as aiodns returns it
+
+    async def query_side_effect(domain, record_type):
+        if record_type == "CNAME" and domain == "example.com":
+            return cname_result
+        if domain != "example.com":
+            received_targets.append(domain)
+        raise make_error(NXDOMAIN)
+
+    handler.takeover_detector.aiodns_resolver.query = query_side_effect
+
+    await handler.takeover_detector.check_dangling_cname_async(domain_context, "example.com")
+
+    # The recursive call must use the normalised form with trailing dot
+    assert any(t == "gbe8q5o.impervadns.net." for t in received_targets)
+
+
 async def test_a_record_exists_not_dangling(handler, domain_context):
     """If the A record resolves, the domain is not dangling."""
 


### PR DESCRIPTION
## Summary

`aiodns` returns CNAME targets without a trailing dot (e.g. `gbe8q5o.impervadns.net`), but every pattern in `config.json` ends with `\\.` which requires one. This meant **no dangling CNAME has ever been classified** — every entry fell through to `unknown|Unclassified|N/A` regardless of which service it pointed to.

This is the second of two stacked bugs (the first was the config key spelling mismatch fixed in #54). Together they explain why all 592 dangling CNAMEs in recent runs appeared as unclassified.

## Fix

One line in `takeover_detector.py`: normalise the CNAME target to always have a trailing dot immediately after reading `cname_answer.cname`.

## Test plan

- [ ] New test `test_cname_target_without_trailing_dot_is_normalised` verifies the recursive call uses the dot-normalised form
- [ ] All 140 tests pass
- [ ] Re-run against domain list — classified entries (Imperva, Azure, Heroku, etc.) now appear individually in the run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)