### PR TITLE
Dep audit + secret scan v1.8.0 — closes #56, closes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#50](https://github.com/incendiary/DNSResolver/issues/50) | ✅ v1.5.0 | AI-assisted code review and refactoring pass using [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) guidelines — surgical changes, simplicity-first, no speculative abstractions |
 | [#52](https://github.com/incendiary/DNSResolver/issues/52) | ✅ v1.6.0 | Refine run summary — elevate classified takeover candidates, collapse unclassified noise to a count |
 | [#54](https://github.com/incendiary/DNSResolver/issues/54) | ✅ v1.7.0 | Expand domain categorisation patterns — fix key mismatch bug, remove proprietary entry, add 11 missing takeover services |
-| [#56](https://github.com/incendiary/DNSResolver/issues/56) | [ ] v1.8.0 | Formal git history secret scan — confirm no credentials, internal hostnames, or tokens in history |
-| [#57](https://github.com/incendiary/DNSResolver/issues/57) | [ ] v1.8.0 | Dependency audit — run pip-audit against all requirements files and resolve any high/critical CVEs |
+| [#56](https://github.com/incendiary/DNSResolver/issues/56) | ✅ v1.8.0 | Formal git history secret scan — confirm no credentials, internal hostnames, or tokens in history |
+| [#57](https://github.com/incendiary/DNSResolver/issues/57) | ✅ v1.8.0 | Dependency audit — run pip-audit against all requirements files and resolve any high/critical CVEs |
 
 ## Contributing
 

--- a/requirements-lambda.txt
+++ b/requirements-lambda.txt
@@ -2,4 +2,4 @@
 # boto3 is pre-installed in the Lambda runtime but included here so the
 # container image is self-contained and testable locally.
 -r requirements.txt
-boto3~=1.34.0
+boto3>=1.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ dnspython>=2.2.1
 requests>=2.28.1
 urllib3>=2.6.3
 tqdm>=4.64.1
-argparse~=1.4.0
 aiodns~=4.0.0
 aiofiles~=24.1.0
 


### PR DESCRIPTION
## Summary

- **gitleaks** scanned 160 commits (~684 KB) — zero leaks found; git history is clean and safe to retain
- **pip-audit** scanned all requirements files — no CVEs found
- Remove `argparse~=1.4.0` from `requirements.txt` — `argparse` has been part of the Python stdlib since 3.2 and the PyPI backport should not be pinned
- Widen `boto3~=1.34.0` → `boto3>=1.34.0` in `requirements-lambda.txt` — the `~=1.34.0` constraint meant `<1.35`, but the runtime was already running 1.43.x; this corrects the pin without breaking anything
- Mark #56 and #57 ✅ v1.8.0 in the README roadmap

Closes #56
Closes #57

## Test plan

- [ ] `pip install -r requirements.txt` resolves without errors
- [ ] `pip install -r requirements-lambda.txt` resolves without errors
- [ ] `pip-audit -r requirements.txt` reports no vulnerabilities
- [ ] `gitleaks git` reports no leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)