### PR TITLE
Add GitHub Actions CI — lint and test on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint (flake8)
+        run: flake8 .
+
+      - name: Test (pytest)
+        run: pytest --cov=. --cov-report=term-missing

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -1,7 +1,5 @@
 """Tests for RunSummary — verifies stdout output using capsys and tmp_path."""
 
-import pytest
-
 from classes.run_summary import RunSummary
 
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs on all pushes to `main` and all pull requests
- Pipeline: `flake8` (lint) → `pytest --cov` (tests + coverage) against Python 3.12
- Uses pip cache keyed on `requirements-dev.txt` for fast installs
- Fixes a pre-existing `F401` unused import in `tests/test_run_summary.py` that would have failed the first CI run

## Test plan

- [ ] CI workflow appears and triggers on this PR
- [ ] Both lint and test steps pass green
- [ ] Coverage report is visible in the CI log

🤖 Generated with [Claude Code](https://claude.com/claude-code)