### PR TITLE
pre-commit: add gitleaks hook and sync black rev — closes #61

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
 


### PR DESCRIPTION
## Summary

- Add `gitleaks/gitleaks v8.30.1` as the first hook so secret scanning fires at every `git commit`, not just on manual runs
- Bump black `rev` from `24.4.2` → `26.3.1` to match the `black>=26.3.1` minimum in `requirements-dev.txt` (the CVE-2026-32274 fix)

Closes #61

## Test plan

- [ ] `pre-commit validate-config .pre-commit-config.yaml` passes
- [ ] `pre-commit run --all-files` runs gitleaks, black, isort, and flake8 cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)