### PR TITLE
ci: install requirements-lambda.txt so boto3 is available for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: requirements-dev.txt
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r requirements-dev.txt -r requirements-lambda.txt
 
       - name: Lint (flake8)
         run: flake8 .


### PR DESCRIPTION
## Summary

CI has been failing on all runs with `ModuleNotFoundError: No module named 'boto3'`.

`lambda_handler.py` imports `boto3` at the module level. `test_lambda_handler.py` patches it, but `patch()` must be able to import the module first. `boto3` lives only in `requirements-lambda.txt`, which the CI workflow was not installing.

Fix: install both `requirements-dev.txt` and `requirements-lambda.txt` in the install step. The two files share `-r requirements.txt` as a base so there are no conflicts.

## Test plan

- [ ] CI run on this PR goes green (all 140 tests pass, flake8 clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)