### PR TITLE
ci: bump actions to Node.js 24 before June 2 deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node.js 20 runners on June 2 2026 and removing them September 16 2026. Both actions in the CI workflow were flagged:

- `actions/checkout@v4` → `actions/checkout@v6` (Node.js 24)
- `actions/setup-python@v5` → `actions/setup-python@v6` (Node.js 24)

## Test plan

- [ ] CI run on this PR goes green with no Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)