### PR TITLE
fix: resolve bugs #72 #73 #75 #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,15 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#57](https://github.com/incendiary/DNSResolver/issues/57) | ✅ v1.8.0 | Dependency audit — run pip-audit against all requirements files and resolve any high/critical CVEs |
 | [#60](https://github.com/incendiary/DNSResolver/issues/60) | ✅ v1.8.0 | GitHub Actions CI — flake8 + pytest on Python 3.12 for all PRs and pushes to main |
 | [#61](https://github.com/incendiary/DNSResolver/issues/61) | ✅ v1.8.0 | pre-commit: add gitleaks hook at commit time; sync black rev to CVE-fixed 26.3.1 |
-| [#63](https://github.com/incendiary/DNSResolver/issues/63) | [ ] v1.9.0 | Dead code removal — unreachable guards in `cloud_service_provider_checks` and `config_resolver` |
-| [#64](https://github.com/incendiary/DNSResolver/issues/64) | [ ] v1.9.0 | Deduplicate `fetch_google_cloud_ip_ranges` / `fetch_aws_ip_ranges` into a shared helper |
-| [#65](https://github.com/incendiary/DNSResolver/issues/65) | [ ] v1.9.0 | Strip what-not-why docstrings from `cloud_ip_ranges.py` |
+| [#63](https://github.com/incendiary/DNSResolver/issues/63) | ✅ v1.9.0 | Dead code removal — unreachable guards in `cloud_service_provider_checks` and `config_resolver` |
+| [#64](https://github.com/incendiary/DNSResolver/issues/64) | ✅ v1.9.0 | Deduplicate `fetch_google_cloud_ip_ranges` / `fetch_aws_ip_ranges` into a shared helper |
+| [#65](https://github.com/incendiary/DNSResolver/issues/65) | ✅ v1.9.0 | Strip what-not-why docstrings from `cloud_ip_ranges.py` |
 | [#66](https://github.com/incendiary/DNSResolver/issues/66) | ✅ v1.8.0 | Branch protection — require CI status check to pass before merge |
+| [#72](https://github.com/incendiary/DNSResolver/issues/72) | [ ] v1.9.0 | Bug: double retry loop — domains retried retries² times due to nested loops in `resolve_domain_async` and `run()` |
+| [#73](https://github.com/incendiary/DNSResolver/issues/73) | [ ] v1.9.0 | Bug: unbounded CNAME recursion in `check_dangling_cname_async` — no depth limit, stack overflow on deep/looping chains |
+| [#74](https://github.com/incendiary/DNSResolver/issues/74) | [ ] v1.9.0 | Bug: concurrent write race in `log_and_write` — duplicate lines possible under high concurrency |
+| [#75](https://github.com/incendiary/DNSResolver/issues/75) | [ ] v1.9.0 | Bug: `asyncio.get_event_loop()` deprecated in Python 3.10+ — replace with `get_running_loop()` |
+| [#76](https://github.com/incendiary/DNSResolver/issues/76) | [ ] v1.9.0 | Dead code: `is_dangling_record_async` defined but never called — remove |
 
 ## Contributing
 

--- a/classes/dns_handler.py
+++ b/classes/dns_handler.py
@@ -59,7 +59,7 @@ class DNSHandler:
             )
 
         # Second-opinion check using dnspython — run in executor to avoid blocking the event loop
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(
                 None, self.dnspython_resolver.resolve, current_domain, "A"
@@ -90,37 +90,19 @@ class DNSHandler:
 
     async def resolve_domain_async(self, domain_context):
         current_domain = domain_context.get_domain()
-        retries = self.env_manager.retries
-        self.env_manager.log_info(
-            f"Starting DNS resolution for {current_domain} with {retries + 1} attempts."
-        )
-
-        for attempt in range(retries + 1):
+        self.env_manager.log_info(f"Resolving {current_domain}")
+        try:
+            answers = await self.aiodns_resolver.query(current_domain, "A")
+            final_ips = [answer.host for answer in answers]
             self.env_manager.log_info(
-                f"Attempt {attempt + 1} for resolving {current_domain}"
+                f"Successfully resolved {current_domain} to {final_ips}"
             )
-            try:
-                answers = await self.aiodns_resolver.query(current_domain, "A")
-                final_ips = [answer.host for answer in answers]
-                self.env_manager.log_info(
-                    f"Successfully resolved {current_domain} to {final_ips}"
-                )
-                await self.takeover_detector.handle_takeover_checks(
-                    domain_context, current_domain
-                )
-                return True, final_ips
-            except aiodns.error.DNSError as e:
-                self.env_manager.log_info(
-                    f"DNS error on attempt {attempt + 1} of {retries + 1} for {current_domain}: {e}"
-                )
-                final_retry = attempt == retries
-                success, ips = await self.handle_domain_resolution_errors(
-                    domain_context, current_domain, e, final_retry
-                )
-                if success:
-                    return success, ips
-                if final_retry:
-                    self.env_manager.log_info(
-                        f"Failed to resolve {current_domain} after {retries + 1} attempts."
-                    )
-                    return False, []
+            await self.takeover_detector.handle_takeover_checks(
+                domain_context, current_domain
+            )
+            return True, final_ips
+        except aiodns.error.DNSError as e:
+            self.env_manager.log_info(f"DNS error for {current_domain}: {e}")
+            return await self.handle_domain_resolution_errors(
+                domain_context, current_domain, e, final_retry=True
+            )

--- a/classes/takeover_detector.py
+++ b/classes/takeover_detector.py
@@ -7,6 +7,9 @@ from classes.domain_categoriser import DomainCategoriser
 from classes.evidence_collector import EvidenceCollector
 
 
+MAX_CNAME_DEPTH = 20
+
+
 class TakeoverDetector:
     def __init__(self, aiodns_resolver, env_manager):
         self.aiodns_resolver = aiodns_resolver
@@ -26,15 +29,6 @@ class TakeoverDetector:
             for nameserver in self.env_manager.nameservers
         ]
         await asyncio.gather(*tasks)
-
-    async def is_dangling_record_async(self, domain, record_type):
-        try:
-            await self.aiodns_resolver.query(domain, record_type)
-            self.env_manager.log_info(f"Domain {domain} has a valid {record_type} record.")
-            return False
-        except aiodns.error.DNSError as e:
-            self.env_manager.log_info(f"Error querying {record_type} for {domain}: {e}")
-            return is_dns_error_present(e, [NXDOMAIN, SERVFAIL])
 
     async def check_ns_takeover(self, domain_context, domain):
         original_domain = domain_context.get_domain()
@@ -78,7 +72,14 @@ class TakeoverDetector:
             domain_context.add_dangling_domain_to_domains(current_domain)
         return is_dangling or is_nstakeover
 
-    async def check_dangling_cname_async(self, domain_context, current_domain):
+    async def check_dangling_cname_async(self, domain_context, current_domain, depth=0):
+        if depth >= MAX_CNAME_DEPTH:
+            self.env_manager.log_info(
+                f"CNAME chain depth limit ({MAX_CNAME_DEPTH}) reached for "
+                f"{current_domain} — treating as non-dangling"
+            )
+            return False
+
         original_domain = domain_context.get_domain()
         output_files = self.env_manager.output_files
         self.env_manager.log_info(
@@ -95,7 +96,7 @@ class TakeoverDetector:
                 if not target.endswith("."):
                     target += "."
                 self.env_manager.log_info(f"CNAME target: {target}")
-                if await self.check_dangling_cname_async(domain_context, target):
+                if await self.check_dangling_cname_async(domain_context, target, depth + 1):
                     return True
         except aiodns.error.DNSError as e:
             self.env_manager.log_info(f"Error querying CNAME for {current_domain}: {e}")

--- a/tests/test_dns_handler.py
+++ b/tests/test_dns_handler.py
@@ -104,51 +104,6 @@ def test_is_dns_error_present_no_match():
 
 
 # ---------------------------------------------------------------------------
-# is_dangling_record_async
-# ---------------------------------------------------------------------------
-
-
-async def test_is_dangling_record_returns_false_when_record_exists(handler):
-    """A successful DNS query means the record exists — not dangling."""
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        return_value=[dns_answer("1.2.3.4")]
-    )
-
-    result = await handler.takeover_detector.is_dangling_record_async("example.com", "A")
-
-    assert result is False
-
-
-async def test_is_dangling_record_returns_true_for_nxdomain(handler):
-    """NXDOMAIN means the record is gone — dangling."""
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        side_effect=make_nxdomain()
-    )
-
-    result = await handler.takeover_detector.is_dangling_record_async(
-        "gone.example.com", "A"
-    )
-
-    assert result is True
-
-
-async def test_is_dangling_record_returns_false_for_timeout(handler):
-    """
-    A timeout means we can't tell — we conservatively say not dangling
-    rather than risk a false positive.
-    """
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        side_effect=make_timeout()
-    )
-
-    result = await handler.takeover_detector.is_dangling_record_async(
-        "slow.example.com", "A"
-    )
-
-    assert result is False
-
-
-# ---------------------------------------------------------------------------
 # resolve_domain_async — happy path
 # ---------------------------------------------------------------------------
 
@@ -181,20 +136,20 @@ async def test_resolve_domain_async_exhausted_retries_returns_false(
     assert ips == []
 
 
-async def test_resolve_domain_async_retries_before_giving_up(
+async def test_resolve_domain_async_makes_single_attempt(
     handler, domain_context, mock_env_manager
 ):
     """
-    The handler should attempt the query (retries + 1) times before
-    declaring failure.  We configure 2 retries, so expect 3 total calls.
+    resolve_domain_async makes exactly one DNS query per call.
+    Retry orchestration is the responsibility of the outer run() loop,
+    not the handler itself.
     """
-    mock_env_manager.retries = 2
     handler.aiodns_resolver.query = AsyncMock(side_effect=make_nxdomain())
     handler.handle_domain_resolution_errors = AsyncMock(return_value=(False, []))
 
     await handler.resolve_domain_async(domain_context)
 
-    assert handler.aiodns_resolver.query.call_count == 3
+    assert handler.aiodns_resolver.query.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dns_handler_resolution.py
+++ b/tests/test_dns_handler_resolution.py
@@ -4,7 +4,6 @@ Tests for the harder-to-reach dns_handler paths:
   - handle_domain_resolution_errors (dnspython fallback, SERVFAIL logging)
   - check_dangling_cname_async (CNAME chain, A/AAAA/MX success, NO_DATA, TIMEOUT)
   - categorise_domain (match and no-match)
-  - is_dangling_record_async
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -289,33 +288,3 @@ def test_categorise_domain_returns_unknown_when_no_match():
     assert category == "unknown"
     assert recommendation == "Unclassified"
     assert evidence == "N/A"
-
-
-# ---------------------------------------------------------------------------
-# is_dangling_record_async
-# ---------------------------------------------------------------------------
-
-
-async def test_is_dangling_record_false_when_record_exists(handler):
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        return_value=[MagicMock()]
-    )
-    result = await handler.takeover_detector.is_dangling_record_async("example.com", "A")
-    assert result is False
-
-
-async def test_is_dangling_record_true_on_nxdomain(handler):
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        side_effect=make_error(NXDOMAIN)
-    )
-    result = await handler.takeover_detector.is_dangling_record_async("example.com", "A")
-    assert result is True
-
-
-async def test_is_dangling_record_true_on_servfail(handler):
-    # SERVFAIL is treated as a dangling indicator alongside NXDOMAIN
-    handler.takeover_detector.aiodns_resolver.query = AsyncMock(
-        side_effect=make_error(SERVFAIL)
-    )
-    result = await handler.takeover_detector.is_dangling_record_async("example.com", "A")
-    assert result is True


### PR DESCRIPTION
## Summary

Four bugs identified during pre-release audit, resolved in a single commit.

**#72 — Double retry loop (behaviour bug)**
`resolve_domain_async` had its own inner `for attempt in range(retries + 1)` loop *and* `run()` had an outer retry loop re-queuing failed domains. With `--retries 2` a domain could receive 9 attempts instead of 3. Fixed by removing the inner loop — `resolve_domain_async` now makes one attempt per call; `run()` owns retry orchestration.

**#73 — Unbounded CNAME recursion (crash bug)**
`check_dangling_cname_async` recursed into CNAME targets with no depth limit. A chain of 1000+ hops (or a CNAME loop) would raise `RecursionError`. Fixed by adding `MAX_CNAME_DEPTH = 20` — chains beyond that are treated as non-dangling.

**#74 — Write race (closed, not a real bug)**
Investigated and closed — `log_and_write` is synchronous and called without `await`, so asyncio's cooperative scheduler makes the read-check-write sequence atomic. No fix needed.

**#75 — Deprecated `get_event_loop()` (deprecation warning)**
Replaced `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `dns_handler.py`. The former emits `DeprecationWarning` in Python 3.10+ when called from a running coroutine.

**#76 — Dead code: `is_dangling_record_async` (dead code)**
Removed the method and all 6 associated tests across two test files.

## Test plan

- [x] 134 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)