### PR TITLE
fix: resilient Azure IP range fetch with cache and pinned fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .pytest_cache/
 .coverage
 .idea/
+.azure_ip_cache.json

--- a/README.md
+++ b/README.md
@@ -284,6 +284,37 @@ Domain processing uses `asyncio.gather` with a `Semaphore` cap (`--max-threads`)
 
 `config.json` sets defaults for timeout, retries, output directory, and domain categorisation patterns used for classifying dangling CNAME targets (e.g. AWS S3, GitHub Pages, Heroku). CLI flags always override config file values.
 
+## Azure IP range fetching
+
+Microsoft publishes Azure IP ranges via a confirmation page that redirects to a weekly-updated JSON file. The download URL changes every week, making a direct scrape fragile. DNSResolver uses a three-stage fallback chain so a broken confirmation page never silently disables Azure matching:
+
+| Stage | Source | Behaviour |
+|-------|--------|-----------|
+| 1 | Microsoft confirmation page (live scrape) | Attempted first on every run. On success the result is written to `.azure_ip_cache.json` for future fallback. |
+| 2 | `.azure_ip_cache.json` (local cache) | Used automatically if the scrape fails. A warning is printed. |
+| 3 | `AZURE_PINNED_URL` (hardcoded fallback) | Used if no cache exists. Points to the latest known-good file at the time of the last release. A warning is printed. |
+| — | Exhausted | If all three sources fail, a clear error is printed and Azure matching is skipped for the run. |
+
+### Keeping the pinned URL current
+
+`AZURE_PINNED_URL` is a module-level constant at the top of `imports/cloud_ip_ranges.py`. When Microsoft rotates the weekly file and the cache ages, update it:
+
+```bash
+# Find the current URL
+python3 -c "
+from urllib.request import urlopen; import re
+with urlopen('https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519') as r:
+    m = re.search(r'https://download\.microsoft\.com/download/[^\"]+\.json', r.read().decode())
+    print(m.group(0) if m else 'not found')
+"
+```
+
+Then update `AZURE_PINNED_URL` in `imports/cloud_ip_ranges.py` and commit.
+
+### Cache file
+
+`.azure_ip_cache.json` is written to the working directory on every successful fetch and is excluded from version control via `.gitignore`. Delete it to force a fresh fetch on the next run.
+
 ## Using with other tools
 
 DNSResolver takes a flat domain list as input. The following external tools are useful for building that list before running a scan.
@@ -357,6 +388,7 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#74](https://github.com/incendiary/DNSResolver/issues/74) | ✅ v1.9.0 | Bug: concurrent write race in `log_and_write` — investigated, not a real bug in asyncio cooperative model |
 | [#75](https://github.com/incendiary/DNSResolver/issues/75) | ✅ v1.9.0 | Bug: `asyncio.get_event_loop()` deprecated in Python 3.10+ — replace with `get_running_loop()` |
 | [#76](https://github.com/incendiary/DNSResolver/issues/76) | ✅ v1.9.0 | Dead code: `is_dangling_record_async` defined but never called — remove |
+| [#79](https://github.com/incendiary/DNSResolver/issues/79) | ✅ v1.9.1 | Bug: Azure IP range fetch brittle — scrapes HTML confirmation page; add cache + pinned URL fallback chain |
 
 ## Contributing
 

--- a/imports/cloud_ip_ranges.py
+++ b/imports/cloud_ip_ranges.py
@@ -116,27 +116,83 @@ def fetch_aws_ip_ranges(output_dir: str, extreme: bool = False) -> Tuple[List, L
     )
 
 
-def fetch_azure_ip_ranges(output_dir: str, extreme: bool = False) -> Tuple[List, List]:
-    url = "https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519"
+# Pinned as of 2026-05-10. Update when Microsoft rotates the file.
+AZURE_PINNED_URL = (
+    "https://download.microsoft.com/download/7/1/d/"
+    "71d86715-5596-4529-9b13-da13a5de5b63/ServiceTags_Public_20260504.json"
+)
+AZURE_CACHE_PATH = ".azure_ip_cache.json"
+
+
+def _save_azure_cache(ranges: Tuple[List, List]) -> None:
     try:
-        with urlopen(url) as response:
-            html = response.read().decode("utf-8")
-            download_link = re.search(
-                r'https://download\.microsoft\.com/download/[^"]+', html
-            )
-            if download_link:
-                json_url = download_link.group(0)
-                ranges = fetch_ip_ranges_for_azure(json_url, extreme)
-                with open(
-                    os.path.join(output_dir, "azure_ip_ranges.json"),
-                    "w",
-                    encoding="utf-8",
-                ) as f:
-                    json.dump(ranges, f, indent=4)
-                return ranges
-            print("Failed to find download link in the Azure IP ranges page.")
-    except requests.exceptions.RequestException as e:
-        print(f"An error occurred while fetching Azure Cloud IP ranges: {e}")
+        with open(AZURE_CACHE_PATH, "w", encoding="utf-8") as f:
+            json.dump(ranges, f, indent=4)
     except IOError as e:
-        print(f"An error occurred while writing the Azure IP file: {e}")
+        print(f"Warning: could not write Azure IP cache: {e}")
+
+
+def _load_azure_cache() -> Tuple[List, List]:
+    with open(AZURE_CACHE_PATH, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data[0], data[1]
+
+
+def fetch_azure_ip_ranges(output_dir: str, extreme: bool = False) -> Tuple[List, List]:
+    confirmation_url = (
+        "https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519"
+    )
+    json_url = None
+
+    # Step 1: scrape the confirmation page for the current download URL
+    try:
+        with urlopen(confirmation_url, timeout=10) as response:
+            html = response.read().decode("utf-8")
+            match = re.search(
+                r'https://download\.microsoft\.com/download/[^"]+\.json', html
+            )
+            if match:
+                json_url = match.group(0)
+            else:
+                print("Azure IP fetch: download link not found on confirmation page.")
+    except Exception as e:
+        print(f"Azure IP fetch: confirmation page unavailable — {e}")
+
+    # Step 2: if scrape succeeded, fetch and return
+    if json_url:
+        ranges = fetch_ip_ranges_for_azure(json_url, extreme)
+        if ranges != ([], []):
+            _save_azure_cache(ranges)
+            with open(
+                os.path.join(output_dir, "azure_ip_ranges.json"), "w", encoding="utf-8"
+            ) as f:
+                json.dump(ranges, f, indent=4)
+            return ranges
+
+    # Step 3: scrape failed — try local cache
+    if os.path.exists(AZURE_CACHE_PATH):
+        print(
+            f"Azure IP fetch: using cached ranges from '{AZURE_CACHE_PATH}'. "
+            "To fetch fresh data set AZURE_PINNED_URL to the latest Microsoft download URL."
+        )
+        try:
+            return _load_azure_cache()
+        except Exception as e:
+            print(f"Azure IP fetch: cache load failed — {e}")
+
+    # Step 4: no cache — fall back to pinned URL
+    print(
+        f"Azure IP fetch: no cache found, falling back to pinned URL ({AZURE_PINNED_URL}). "
+        "This may be stale — update AZURE_PINNED_URL in cloud_ip_ranges.py if needed."
+    )
+    ranges = fetch_ip_ranges_for_azure(AZURE_PINNED_URL, extreme)
+    if ranges != ([], []):
+        _save_azure_cache(ranges)
+        with open(
+            os.path.join(output_dir, "azure_ip_ranges.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump(ranges, f, indent=4)
+        return ranges
+
+    print("Azure IP fetch: all sources exhausted — no Azure ranges loaded.")
     return [], []

--- a/tests/test_cloud_ip_ranges.py
+++ b/tests/test_cloud_ip_ranges.py
@@ -159,19 +159,52 @@ def test_fetch_aws_ip_ranges_writes_json(tmp_path):
     assert (tmp_path / "aws_ip_ranges.json").exists()
 
 
-def test_fetch_azure_ip_ranges_writes_json(tmp_path):
-    html = b'<html><a href="https://download.microsoft.com/download/fake.json">link</a></html>'
+def _mock_urlopen(html: bytes):
+    """Return a context-manager mock for urlopen that yields the given HTML."""
     mock_resp = MagicMock()
     mock_resp.read.return_value = html
     mock_resp.__enter__ = lambda s: s
     mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
 
+
+AZURE_DOWNLOAD_HTML = (
+    b'<html><a href="https://download.microsoft.com/download/fake.json">link</a></html>'
+)
+
+
+def test_fetch_azure_ip_ranges_scrape_success_writes_json_and_cache(tmp_path):
     with (
-        patch("imports.cloud_ip_ranges.urlopen", return_value=mock_resp),
-        patch(
-            "imports.cloud_ip_ranges.fetch_ip_ranges_for_azure",
-            return_value=(["13.64.0.0/11"], []),
-        ),
+        patch("imports.cloud_ip_ranges.urlopen", return_value=_mock_urlopen(AZURE_DOWNLOAD_HTML)),
+        patch("imports.cloud_ip_ranges.fetch_ip_ranges_for_azure", return_value=(["13.64.0.0/11"], [])),
+        patch("imports.cloud_ip_ranges._save_azure_cache") as mock_cache,
+    ):
+        result = fetch_azure_ip_ranges(str(tmp_path))
+
+    assert result == (["13.64.0.0/11"], [])
+    assert (tmp_path / "azure_ip_ranges.json").exists()
+    mock_cache.assert_called_once_with((["13.64.0.0/11"], []))
+
+
+def test_fetch_azure_ip_ranges_scrape_fails_uses_local_cache(tmp_path):
+    """When the confirmation page is unreachable, fall back to the local cache."""
+    with (
+        patch("imports.cloud_ip_ranges.urlopen", side_effect=Exception("timeout")),
+        patch("imports.cloud_ip_ranges.os.path.exists", return_value=True),
+        patch("imports.cloud_ip_ranges._load_azure_cache", return_value=(["13.64.0.0/11"], [])),
+    ):
+        result = fetch_azure_ip_ranges(str(tmp_path))
+
+    assert result == (["13.64.0.0/11"], [])
+
+
+def test_fetch_azure_ip_ranges_scrape_fails_no_cache_uses_pinned(tmp_path):
+    """When scrape fails and there is no cache, the pinned URL is tried."""
+    with (
+        patch("imports.cloud_ip_ranges.urlopen", side_effect=Exception("timeout")),
+        patch("imports.cloud_ip_ranges.os.path.exists", return_value=False),
+        patch("imports.cloud_ip_ranges.fetch_ip_ranges_for_azure", return_value=(["13.64.0.0/11"], [])),
+        patch("imports.cloud_ip_ranges._save_azure_cache"),
     ):
         result = fetch_azure_ip_ranges(str(tmp_path))
 
@@ -179,14 +212,13 @@ def test_fetch_azure_ip_ranges_writes_json(tmp_path):
     assert (tmp_path / "azure_ip_ranges.json").exists()
 
 
-def test_fetch_azure_ip_ranges_no_download_link_returns_empty(tmp_path):
-    html = b"<html>no link here</html>"
-    mock_resp = MagicMock()
-    mock_resp.read.return_value = html
-    mock_resp.__enter__ = lambda s: s
-    mock_resp.__exit__ = MagicMock(return_value=False)
-
-    with patch("imports.cloud_ip_ranges.urlopen", return_value=mock_resp):
+def test_fetch_azure_ip_ranges_all_sources_fail_returns_empty(tmp_path):
+    """When scrape, cache, and pinned URL all fail, return empty lists."""
+    with (
+        patch("imports.cloud_ip_ranges.urlopen", side_effect=Exception("timeout")),
+        patch("imports.cloud_ip_ranges.os.path.exists", return_value=False),
+        patch("imports.cloud_ip_ranges.fetch_ip_ranges_for_azure", return_value=([], [])),
+    ):
         result = fetch_azure_ip_ranges(str(tmp_path))
 
     assert result == ([], [])


### PR DESCRIPTION
## Summary

The Microsoft confirmation page scrape in `fetch_azure_ip_ranges` is fragile — Microsoft changes the page structure occasionally, silently breaking Azure IP matching for all runs until noticed.

New fallback chain:

1. **Scrape** the confirmation page for the current download URL → success: fetch, write output, update `.azure_ip_cache.json`
2. **Cache** — if scrape fails and `.azure_ip_cache.json` exists, warn and return cached ranges
3. **Pinned URL** — if no cache, try `AZURE_PINNED_URL` (pinned to `ServiceTags_Public_20260504.json` as of 2026-05-10). Update the constant when Microsoft rotates the file.
4. **Exhausted** — if all three fail, warn and return `[], []`

`AZURE_PINNED_URL` and `AZURE_CACHE_PATH` are module-level constants — easy to update. Cache file added to `.gitignore`.

## Test plan

- [x] 4 new tests cover each fallback path (scrape success, cache fallback, pinned fallback, all fail)
- [x] 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)