### PR TITLE
fix: classify dangling AWS ELB CNAMEs (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#75](https://github.com/incendiary/DNSResolver/issues/75) | ✅ v1.9.0 | Bug: `asyncio.get_event_loop()` deprecated in Python 3.10+ — replace with `get_running_loop()` |
 | [#76](https://github.com/incendiary/DNSResolver/issues/76) | ✅ v1.9.0 | Dead code: `is_dangling_record_async` defined but never called — remove |
 | [#79](https://github.com/incendiary/DNSResolver/issues/79) | ✅ v1.9.1 | Bug: Azure IP range fetch brittle — scrapes HTML confirmation page; add cache + pinned URL fallback chain |
+| [#80](https://github.com/incendiary/DNSResolver/issues/80) | ✅ v1.9.2 | Bug: dangling CNAMEs to AWS ELB classified as unknown — add `aws_elb` pattern (`*.elb.amazonaws.com`) |
 
 ## Contributing
 

--- a/config.json
+++ b/config.json
@@ -50,6 +50,11 @@
             "recommendation": "Delete the CNAME — the Elastic Beanstalk environment has been terminated; the subdomain may be reclaimable",
             "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/97"
         },
+        "aws_elb": {
+            "regex": "\\.elb\\.amazonaws\\.com\\.",
+            "recommendation": "Delete the CNAME — the AWS Elastic Load Balancer no longer exists; ELB names are region-scoped and can be claimed by any AWS account in the same region",
+            "evidence": "https://github.com/EdOverflow/can-i-take-over-xyz/issues/137"
+        },
         "aws_s3": {
             "regex": "\\.s3\\.amazonaws\\.com\\.|\\.s3-website[.-][a-z0-9-]+\\.amazonaws\\.com\\.|\\.s3\\.dualstack\\.[a-z0-9-]+\\.amazonaws\\.com\\.",
             "recommendation": "Delete the CNAME or recreate the S3 bucket — unclaimed buckets can be registered by anyone in the same region",


### PR DESCRIPTION
## Summary

Closes #80.

Dangling CNAMEs to deleted AWS Elastic Load Balancers (`*.{region}.elb.amazonaws.com.`) were falling through as `unknown/Unclassified`. These are a well-documented subdomain takeover vector — ELB names are region-scoped and can be claimed by any AWS account in the same region once the original load balancer is deleted.

Added `aws_elb` to `domain_categorisation` in `config.json` with the appropriate recommendation and evidence link.

## Test plan

- [x] Regex verified to match `*.{region}.elb.amazonaws.com.` format
- [x] 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)