### PR TITLE
feat: consolidate output files — 7 text files → 4 (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,8 @@ Each run creates a timestamped subdirectory under the output directory containin
 |------|----------|
 | `resolution_results_*.txt` | Successfully resolved domains and their DNS records |
 | `unresolved_results_*.txt` | Domains that could not be resolved after all retries |
-| `dangling_cname_results_*.txt` | Domains with dangling CNAMEs — category, recommendation, and evidence link |
-| `ns_takeover_results_*.txt` | Domains with potentially unresolvable nameservers |
-| `gcp_results_*.txt` | Domains resolving to GCP IP ranges |
-| `aws_results_*.txt` | Domains resolving to AWS IP ranges |
-| `azure_results_*.txt` | Domains resolving to Azure IP ranges |
+| `takeover_candidates_*.txt` | Takeover candidates — `DANGLING\|` lines (dangling CNAMEs with category, recommendation, evidence) and `NS_TAKEOVER\|` lines (unresolvable nameservers) |
+| `csp_matches_*.txt` | Domains resolving to cloud provider IP ranges (AWS, GCP, Azure — one line per match) |
 | `environment_results_*.json` | Run metadata (command, external IP, Docker status) |
 | `evidence/dns/` | dig or nslookup output per flagged domain (when `--evidence` is set) |
 

--- a/classes/output_manager.py
+++ b/classes/output_manager.py
@@ -20,11 +20,8 @@ class OutputManager:
             "standard": {
                 "resolved": os.path.join(d, f"resolution_results_{timestamp}.txt"),
                 "unresolved": os.path.join(d, f"unresolved_results_{timestamp}.txt"),
-                "gcp": os.path.join(d, f"gcp_results_{timestamp}.txt"),
-                "aws": os.path.join(d, f"aws_results_{timestamp}.txt"),
-                "azure": os.path.join(d, f"azure_results_{timestamp}.txt"),
-                "dangling": os.path.join(d, f"dangling_cname_results_{timestamp}.txt"),
-                "ns_takeover": os.path.join(d, f"ns_takeover_results_{timestamp}.txt"),
+                "csp": os.path.join(d, f"csp_matches_{timestamp}.txt"),
+                "takeover": os.path.join(d, f"takeover_candidates_{timestamp}.txt"),
                 "environment": os.path.join(d, f"environment_results_{timestamp}.json"),
                 "timeout": os.path.join(d, f"timeout_results_{timestamp}.txt"),
             }

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -19,11 +19,19 @@ class RunSummary:
     def display(self, total_input, failed_count):
         resolved_count = len(self._lines("resolved"))
         unresolved_count = len(self._lines("unresolved"))
-        dangling = self._lines("dangling")
-        ns_takeover = self._lines("ns_takeover")
-        aws_count = len(self._lines("aws"))
-        gcp_count = len(self._lines("gcp"))
-        azure_count = len(self._lines("azure"))
+
+        takeover_lines = self._lines("takeover")
+        dangling = [
+            ln[len("DANGLING|"):] for ln in takeover_lines if ln.startswith("DANGLING|")
+        ]
+        ns_takeover = [
+            ln[len("NS_TAKEOVER|"):] for ln in takeover_lines if ln.startswith("NS_TAKEOVER|")
+        ]
+
+        csp_lines = self._lines("csp")
+        aws_count = sum(1 for ln in csp_lines if "resolved to aws IPs" in ln)
+        gcp_count = sum(1 for ln in csp_lines if "resolved to gcp IPs" in ln)
+        azure_count = sum(1 for ln in csp_lines if "resolved to azure IPs" in ln)
 
         classified = {}
         unclassified_count = 0
@@ -82,12 +90,12 @@ class RunSummary:
 
             if unclassified_count:
                 print()
-                dangling_file = os.path.basename(
-                    self._files.get("dangling", "dangling_cname_results.txt")
+                takeover_file = os.path.basename(
+                    self._files.get("takeover", "takeover_candidates.txt")
                 )
                 print(
                     f"  Unclassified dangling CNAMEs : {unclassified_count}"
-                    f"  (see {dangling_file})"
+                    f"  (see {takeover_file})"
                 )
 
         print(thin)

--- a/classes/takeover_detector.py
+++ b/classes/takeover_detector.py
@@ -44,8 +44,8 @@ class TakeoverDetector:
                 except aiodns.error.DNSError as e:
                     if is_dns_error_present(e, [NXDOMAIN, SERVFAIL]):
                         await self.env_manager.write_to_file(
-                            output_files["standard"]["ns_takeover"],
-                            f"{original_domain}|{domain}",
+                            output_files["standard"]["takeover"],
+                            f"NS_TAKEOVER|{original_domain}|{domain}",
                         )
                         self.env_manager.log_info(
                             f"NS takeover possible for domain {domain}"
@@ -138,8 +138,8 @@ class TakeoverDetector:
             current_domain, patterns
         )
         await self.env_manager.write_to_file(
-            output_files["standard"]["dangling"],
-            f"{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}",
+            output_files["standard"]["takeover"],
+            f"DANGLING|{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}",
         )
         self.env_manager.log_info(
             f"Domain {current_domain} is a dangling CNAME with category: {category}"

--- a/imports/cloud_service_provider_checks.py
+++ b/imports/cloud_service_provider_checks.py
@@ -87,7 +87,7 @@ def merge_matches(matches_ipv4, matches_ipv6, vendor_ips_context):
 
 def log_and_write(vendor, matched_ips, domain, output_files, domain_context):
     message = f"{domain} resolved to {vendor} IPs: {matched_ips}"
-    file_path = output_files["standard"][vendor]
+    file_path = output_files["standard"]["csp"]
 
     # Deduplicate: skip write if this exact line already exists
     if os.path.exists(file_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,8 @@ def mock_env_manager():
     # Output files the handler writes results to
     env.output_files = {
         "standard": {
-            "dangling": "/tmp/test_dangling.txt",
-            "ns_takeover": "/tmp/test_ns_takeover.txt",
+            "takeover": "/tmp/test_takeover.txt",
+            "csp": "/tmp/test_csp.txt",
             "unresolved": "/tmp/test_unresolved.txt",
             "resolved": "/tmp/test_resolved.txt",
         },

--- a/tests/test_cloud_service_provider_checks.py
+++ b/tests/test_cloud_service_provider_checks.py
@@ -160,9 +160,9 @@ def test_get_ip_matches_skips_wrong_ip_version(ctx):
 
 
 def test_log_and_write_creates_entry(tmp_path, ctx):
-    out_file = tmp_path / "gcp.txt"
+    out_file = tmp_path / "csp.txt"
     out_file.touch()
-    output_files = {"standard": {"gcp": str(out_file)}}
+    output_files = {"standard": {"csp": str(out_file)}}
 
     result = log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
 
@@ -172,9 +172,9 @@ def test_log_and_write_creates_entry(tmp_path, ctx):
 
 def test_log_and_write_no_duplicate_entries(tmp_path, ctx):
     """Writing the same match twice should not produce duplicate lines."""
-    out_file = tmp_path / "gcp.txt"
+    out_file = tmp_path / "csp.txt"
     out_file.touch()
-    output_files = {"standard": {"gcp": str(out_file)}}
+    output_files = {"standard": {"csp": str(out_file)}}
 
     log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
     log_and_write("gcp", ["34.1.2.3"], "example.com", output_files, ctx)
@@ -189,34 +189,26 @@ def test_log_and_write_no_duplicate_entries(tmp_path, ctx):
 
 
 def test_perform_csp_checks_matches_gcp_ip(tmp_path, mock_env_manager, ctx):
-    gcp_file = tmp_path / "gcp.txt"
-    gcp_file.touch()
-    aws_file = tmp_path / "aws.txt"
-    aws_file.touch()
-    azure_file = tmp_path / "azure.txt"
-    azure_file.touch()
+    csp_file = tmp_path / "csp.txt"
+    csp_file.touch()
     mock_env_manager.output_files = {
         "standard": {
-            "gcp": str(gcp_file),
-            "aws": str(aws_file),
-            "azure": str(azure_file),
+            "csp": str(csp_file),
         }
     }
 
     result = perform_csp_checks(ctx, mock_env_manager, ["34.1.2.3"])
 
     assert result is True
-    assert "example.com" in gcp_file.read_text()
+    assert "example.com" in csp_file.read_text()
 
 
 def test_perform_csp_checks_no_match_returns_false(tmp_path, mock_env_manager, ctx):
-    for vendor in ("gcp", "aws", "azure"):
-        (tmp_path / f"{vendor}.txt").touch()
+    csp_file = tmp_path / "csp.txt"
+    csp_file.touch()
     mock_env_manager.output_files = {
         "standard": {
-            "gcp": str(tmp_path / "gcp.txt"),
-            "aws": str(tmp_path / "aws.txt"),
-            "azure": str(tmp_path / "azure.txt"),
+            "csp": str(csp_file),
         }
     }
 

--- a/tests/test_dns_handler.py
+++ b/tests/test_dns_handler.py
@@ -201,7 +201,7 @@ async def test_check_dangling_cname_is_dangling_no_records(
     # Verify the result was written to the dangling output file
     mock_env_manager.write_to_file.assert_called_once()
     call_args = mock_env_manager.write_to_file.call_args
-    assert "/tmp/test_dangling.txt" in call_args[0]
+    assert "/tmp/test_takeover.txt" in call_args[0]
 
 
 async def test_check_dangling_cname_timeout_is_not_dangling(handler, domain_context):

--- a/tests/test_dns_handler_extended.py
+++ b/tests/test_dns_handler_extended.py
@@ -150,7 +150,7 @@ async def test_check_ns_takeover_returns_true_when_ns_is_nxdomain(
     assert result is True
     mock_env_manager.write_to_file.assert_called_once()
     path, content = mock_env_manager.write_to_file.call_args[0]
-    assert "ns_takeover" in path
+    assert "takeover" in path
 
 
 async def test_check_ns_takeover_returns_false_when_no_ns_records(

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -8,11 +8,8 @@ def _make_summary(tmp_path, files=None):
     standard = {
         "resolved": tmp_path / "resolved.txt",
         "unresolved": tmp_path / "unresolved.txt",
-        "dangling": tmp_path / "dangling.txt",
-        "ns_takeover": tmp_path / "ns_takeover.txt",
-        "aws": tmp_path / "aws.txt",
-        "gcp": tmp_path / "gcp.txt",
-        "azure": tmp_path / "azure.txt",
+        "takeover": tmp_path / "takeover.txt",
+        "csp": tmp_path / "csp.txt",
     }
     for key, path in standard.items():
         content = files.get(key, "") if files else ""
@@ -47,8 +44,11 @@ def test_counts_are_accurate(tmp_path, capsys):
         {
             "resolved": "a.com|1.1.1.1\nb.com|2.2.2.2\n",
             "unresolved": "DNS resolution error for c.com: timeout\n",
-            "aws": "a.com|1.1.1.1\n",
-            "gcp": "b.com|2.2.2.2\nb2.com|3.3.3.3\n",
+            "csp": (
+                "a.com resolved to aws IPs: ['1.1.1.1']\n"
+                "b.com resolved to gcp IPs: ['2.2.2.2']\n"
+                "b2.com resolved to gcp IPs: ['3.3.3.3']\n"
+            ),
         },
     )
     summary.display(total_input=5, failed_count=1)
@@ -66,8 +66,8 @@ def test_counts_are_accurate(tmp_path, capsys):
 
 
 def test_classified_dangling_cname_shown_in_full(tmp_path, capsys):
-    dangling = "root.example.com|app.s3.amazonaws.com|aws_s3|Remove the CNAME|https://evidence.link\n"
-    summary = _make_summary(tmp_path, {"dangling": dangling})
+    dangling = "DANGLING|root.example.com|app.s3.amazonaws.com|aws_s3|Remove the CNAME|https://evidence.link\n"
+    summary = _make_summary(tmp_path, {"takeover": dangling})
     summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
@@ -82,11 +82,11 @@ def test_classified_dangling_cname_shown_in_full(tmp_path, capsys):
 
 def test_classified_cnames_grouped_by_category(tmp_path, capsys):
     dangling = (
-        "a.com|a.herokudns.com|heroku|Remove it|https://heroku.example\n"
-        "b.com|b.herokudns.com|heroku|Remove it|https://heroku.example\n"
-        "c.com|c.s3.amazonaws.com|aws_s3|Remove the CNAME|https://aws.example\n"
+        "DANGLING|a.com|a.herokudns.com|heroku|Remove it|https://heroku.example\n"
+        "DANGLING|b.com|b.herokudns.com|heroku|Remove it|https://heroku.example\n"
+        "DANGLING|c.com|c.s3.amazonaws.com|aws_s3|Remove the CNAME|https://aws.example\n"
     )
-    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary = _make_summary(tmp_path, {"takeover": dangling})
     summary.display(total_input=3, failed_count=0)
 
     out = capsys.readouterr().out
@@ -103,10 +103,10 @@ def test_classified_cnames_grouped_by_category(tmp_path, capsys):
 def test_unclassified_cnames_collapsed_to_count(tmp_path, capsys):
     """Unclassified entries must not appear individually — only a count line."""
     dangling = (
-        "a.com|mystery-target.example.com|unknown|Unclassified|N/A\n"
-        "b.com|another-unknown.example.com|unknown|Unclassified|N/A\n"
+        "DANGLING|a.com|mystery-target.example.com|unknown|Unclassified|N/A\n"
+        "DANGLING|b.com|another-unknown.example.com|unknown|Unclassified|N/A\n"
     )
-    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary = _make_summary(tmp_path, {"takeover": dangling})
     summary.display(total_input=2, failed_count=0)
 
     out = capsys.readouterr().out
@@ -120,11 +120,11 @@ def test_unclassified_cnames_collapsed_to_count(tmp_path, capsys):
 def test_unclassified_count_included_in_total_banner(tmp_path, capsys):
     """Unclassified dangles must count toward the [!] total."""
     dangling = (
-        "a.com|known.herokudns.com|heroku|Remove it|https://h.example\n"
-        "b.com|unknown1.example.com|unknown|Unclassified|N/A\n"
-        "c.com|unknown2.example.com|unknown|Unclassified|N/A\n"
+        "DANGLING|a.com|known.herokudns.com|heroku|Remove it|https://h.example\n"
+        "DANGLING|b.com|unknown1.example.com|unknown|Unclassified|N/A\n"
+        "DANGLING|c.com|unknown2.example.com|unknown|Unclassified|N/A\n"
     )
-    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary = _make_summary(tmp_path, {"takeover": dangling})
     summary.display(total_input=3, failed_count=0)
 
     out = capsys.readouterr().out
@@ -137,10 +137,10 @@ def test_unclassified_count_included_in_total_banner(tmp_path, capsys):
 def test_classified_and_unclassified_split(tmp_path, capsys):
     """Classified entries are shown in full; unclassified collapsed alongside them."""
     dangling = (
-        "a.com|app.herokudns.com|heroku|Remove the app|https://heroku.example\n"
-        "b.com|noise.example.com|unknown|Unclassified|N/A\n"
+        "DANGLING|a.com|app.herokudns.com|heroku|Remove the app|https://heroku.example\n"
+        "DANGLING|b.com|noise.example.com|unknown|Unclassified|N/A\n"
     )
-    summary = _make_summary(tmp_path, {"dangling": dangling})
+    summary = _make_summary(tmp_path, {"takeover": dangling})
     summary.display(total_input=2, failed_count=0)
 
     out = capsys.readouterr().out
@@ -156,8 +156,8 @@ def test_classified_and_unclassified_split(tmp_path, capsys):
 
 
 def test_ns_takeover_flagged(tmp_path, capsys):
-    ns = "vuln.example.com|ns1.orphaned-registrar.com\n"
-    summary = _make_summary(tmp_path, {"ns_takeover": ns})
+    ns = "NS_TAKEOVER|vuln.example.com|ns1.orphaned-registrar.com\n"
+    summary = _make_summary(tmp_path, {"takeover": ns})
     summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
@@ -167,9 +167,12 @@ def test_ns_takeover_flagged(tmp_path, capsys):
 
 
 def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):
-    dangling = "a.com|a.herokudns.com|heroku|Remove|https://h.example\n"
-    ns = "b.com|ns1.dead.example\nc.com|ns2.dead.example\n"
-    summary = _make_summary(tmp_path, {"dangling": dangling, "ns_takeover": ns})
+    takeover = (
+        "DANGLING|a.com|a.herokudns.com|heroku|Remove|https://h.example\n"
+        "NS_TAKEOVER|b.com|ns1.dead.example\n"
+        "NS_TAKEOVER|c.com|ns2.dead.example\n"
+    )
+    summary = _make_summary(tmp_path, {"takeover": takeover})
     summary.display(total_input=3, failed_count=0)
 
     out = capsys.readouterr().out
@@ -183,7 +186,7 @@ def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):
 
 def test_dangling_line_missing_fields_skipped_gracefully(tmp_path, capsys):
     """A malformed dangling line (< 5 fields) should not crash and is silently ignored."""
-    summary = _make_summary(tmp_path, {"dangling": "only|two\n"})
+    summary = _make_summary(tmp_path, {"takeover": "DANGLING|only|two\n"})
     summary.display(total_input=1, failed_count=0)
 
     out = capsys.readouterr().out
@@ -196,11 +199,8 @@ def test_missing_file_treated_as_empty(tmp_path, capsys):
         "standard": {
             "resolved": "/nonexistent/resolved.txt",
             "unresolved": "/nonexistent/unresolved.txt",
-            "dangling": "/nonexistent/dangling.txt",
-            "ns_takeover": "/nonexistent/ns_takeover.txt",
-            "aws": "/nonexistent/aws.txt",
-            "gcp": "/nonexistent/gcp.txt",
-            "azure": "/nonexistent/azure.txt",
+            "takeover": "/nonexistent/takeover.txt",
+            "csp": "/nonexistent/csp.txt",
         }
     }
     summary = RunSummary(output_files, "/tmp/output")


### PR DESCRIPTION
## Summary

- Merges `dangling_cname_results_*.txt` + `ns_takeover_results_*.txt` → `takeover_candidates_*.txt` with `DANGLING|` / `NS_TAKEOVER|` line prefixes
- Merges `gcp_results_*.txt` + `aws_results_*.txt` + `azure_results_*.txt` → `csp_matches_*.txt` (vendor name embedded in each line)
- Updates `run_summary.py` to parse the new merged formats
- Updates all test fixtures and assertions to match the new keys and line formats
- Updates README output file table

Closes #82.

## Test plan

- [x] All 135 tests pass locally
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)