### PR TITLE
feat: surface all takeover candidates with actionable context (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,8 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#76](https://github.com/incendiary/DNSResolver/issues/76) | ✅ v1.9.0 | Dead code: `is_dangling_record_async` defined but never called — remove |
 | [#79](https://github.com/incendiary/DNSResolver/issues/79) | ✅ v1.9.1 | Bug: Azure IP range fetch brittle — scrapes HTML confirmation page; add cache + pinned URL fallback chain |
 | [#80](https://github.com/incendiary/DNSResolver/issues/80) | ✅ v1.9.2 | Bug: dangling CNAMEs to AWS ELB classified as unknown — add `aws_elb` pattern (`*.elb.amazonaws.com`) |
-| [#82](https://github.com/incendiary/DNSResolver/issues/82) | [ ] v1.10.0 | Consolidate output files: 7 text files → 4 — merge CSP results into `csp_matches_*.txt`, merge takeover files into `takeover_candidates_*.txt` (breaking change) |
+| [#82](https://github.com/incendiary/DNSResolver/issues/82) | ✅ v1.10.0 | Consolidate output files: 7 text files → 4 — merge CSP results into `csp_matches_*.txt`, merge takeover files into `takeover_candidates_*.txt` (breaking change) |
+| [#85](https://github.com/incendiary/DNSResolver/issues/85) | ✅ v1.10.1 | Run summary: show all takeover candidates with actionable context — unclassified CNAMEs listed individually with CNAME target, risk, and recommended action; NS takeover entries include DNS-control risk explanation |
 
 ## Contributing
 

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -34,19 +34,20 @@ class RunSummary:
         azure_count = sum(1 for ln in csp_lines if "resolved to azure IPs" in ln)
 
         classified = {}
-        unclassified_count = 0
+        unclassified = []
         for line in dangling:
             parts = line.split("|")
             if len(parts) >= 5:
                 _orig, current, category, recommendation, evidence = parts[:5]
                 if category == "unknown":
-                    unclassified_count += 1
+                    unclassified.append((_orig, current))
                 else:
                     classified.setdefault(category, []).append(
                         (current, recommendation, evidence)
                     )
 
         classified_count = sum(len(v) for v in classified.values())
+        unclassified_count = len(unclassified)
         total_candidates = classified_count + unclassified_count + len(ns_takeover)
 
         bar = "=" * 64
@@ -68,7 +69,7 @@ class RunSummary:
         if total_candidates == 0:
             print("  No takeover candidates detected.")
         else:
-            print(f"  [!] {total_candidates} TAKEOVER CANDIDATE(S) DETECTED [!]")
+            print(f"  [!] {total_candidates} TAKEOVER CANDIDATE(S) DETECTED — REVIEW IMMEDIATELY [!]")
 
             if classified_count:
                 print()
@@ -86,17 +87,20 @@ class RunSummary:
                 for line in ns_takeover:
                     parts = line.split("|")
                     if len(parts) >= 2:
-                        print(f"    {parts[0]} -> NS: {parts[1]}")
+                        root, ns_host = parts[0], parts[1]
+                        print(f"    {root} -> NS: {ns_host}")
+                        print(f"          Why    : Nameserver does not resolve — registering it gives")
+                        print(f"                   an attacker DNS control over {root} and all its subdomains")
 
-            if unclassified_count:
+            if unclassified:
                 print()
-                takeover_file = os.path.basename(
-                    self._files.get("takeover", "takeover_candidates.txt")
-                )
-                print(
-                    f"  Unclassified dangling CNAMEs : {unclassified_count}"
-                    f"  (see {takeover_file})"
-                )
+                print(f"  Unclassified dangling CNAMEs ({unclassified_count}) — investigate manually")
+                for root_domain, cname_target in unclassified:
+                    print(f"    [?] {root_domain}")
+                    print(f"          CNAME target : {cname_target}")
+                    print(f"          Risk         : Target does not resolve — if it can be claimed,")
+                    print(f"                         an attacker can serve content from {root_domain}")
+                    print(f"          Action       : Verify this CNAME is intentional; remove it if not")
 
         print(thin)
         print(f"  Output : {self._output_dir}")

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -1,6 +1,3 @@
-import os
-
-
 class RunSummary:
     def __init__(self, output_files, output_dir):
         self._files = output_files["standard"]
@@ -89,7 +86,7 @@ class RunSummary:
                     if len(parts) >= 2:
                         root, ns_host = parts[0], parts[1]
                         print(f"    {root} -> NS: {ns_host}")
-                        print(f"          Why    : Nameserver does not resolve — registering it gives")
+                        print("          Why    : Nameserver does not resolve — registering it gives")
                         print(f"                   an attacker DNS control over {root} and all its subdomains")
 
             if unclassified:
@@ -98,9 +95,9 @@ class RunSummary:
                 for root_domain, cname_target in unclassified:
                     print(f"    [?] {root_domain}")
                     print(f"          CNAME target : {cname_target}")
-                    print(f"          Risk         : Target does not resolve — if it can be claimed,")
+                    print("          Risk         : Target does not resolve — if it can be claimed,")
                     print(f"                         an attacker can serve content from {root_domain}")
-                    print(f"          Action       : Verify this CNAME is intentional; remove it if not")
+                    print("          Action       : Verify this CNAME is intentional; remove it if not")
 
         print(thin)
         print(f"  Output : {self._output_dir}")

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -100,8 +100,8 @@ def test_classified_cnames_grouped_by_category(tmp_path, capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_unclassified_cnames_collapsed_to_count(tmp_path, capsys):
-    """Unclassified entries must not appear individually — only a count line."""
+def test_unclassified_cnames_shown_individually(tmp_path, capsys):
+    """Unclassified entries must appear individually with CNAME target and risk context."""
     dangling = (
         "DANGLING|a.com|mystery-target.example.com|unknown|Unclassified|N/A\n"
         "DANGLING|b.com|another-unknown.example.com|unknown|Unclassified|N/A\n"
@@ -111,9 +111,11 @@ def test_unclassified_cnames_collapsed_to_count(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "[!]" in out
-    assert "Unclassified dangling CNAMEs : 2" in out
-    assert "mystery-target.example.com" not in out
-    assert "another-unknown.example.com" not in out
+    assert "Unclassified dangling CNAMEs (2)" in out
+    assert "mystery-target.example.com" in out
+    assert "another-unknown.example.com" in out
+    assert "Risk" in out
+    assert "Action" in out
     assert "Classified dangling CNAMEs" not in out
 
 
@@ -131,11 +133,11 @@ def test_unclassified_count_included_in_total_banner(tmp_path, capsys):
     # 1 classified + 2 unclassified = 3
     assert "3 TAKEOVER CANDIDATE(S)" in out
     assert "Classified dangling CNAMEs (1)" in out
-    assert "Unclassified dangling CNAMEs : 2" in out
+    assert "Unclassified dangling CNAMEs (2)" in out
 
 
 def test_classified_and_unclassified_split(tmp_path, capsys):
-    """Classified entries are shown in full; unclassified collapsed alongside them."""
+    """Classified entries are shown in full; unclassified shown individually with context."""
     dangling = (
         "DANGLING|a.com|app.herokudns.com|heroku|Remove the app|https://heroku.example\n"
         "DANGLING|b.com|noise.example.com|unknown|Unclassified|N/A\n"
@@ -146,8 +148,8 @@ def test_classified_and_unclassified_split(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "Classified dangling CNAMEs (1)" in out
     assert "app.herokudns.com" in out
-    assert "Unclassified dangling CNAMEs : 1" in out
-    assert "noise.example.com" not in out
+    assert "Unclassified dangling CNAMEs (1)" in out
+    assert "noise.example.com" in out
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +166,8 @@ def test_ns_takeover_flagged(tmp_path, capsys):
     assert "[!]" in out
     assert "NS Takeover candidates (1)" in out
     assert "vuln.example.com -> NS: ns1.orphaned-registrar.com" in out
+    assert "Why" in out
+    assert "DNS control" in out
 
 
 def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- Unclassified dangling CNAMEs are now listed individually in the terminal with their CNAME target, risk statement, and recommended action — no longer collapsed to a count
- NS takeover entries now include a one-line explanation of the DNS-control risk
- Alert banner updated to "REVIEW IMMEDIATELY"

Closes #85.

## Before

```
  Unclassified dangling CNAMEs : 2  (see takeover_candidates.txt)
```

## After

```
  Unclassified dangling CNAMEs (2) — investigate manually
    [?] accend.example.com
          CNAME target : k8s-prod-1234.ap-southeast-1.elb.amazonaws.com.
          Risk         : Target does not resolve — if it can be claimed,
                         an attacker can serve content from accend.example.com
          Action       : Verify this CNAME is intentional; remove it if not
```

## Test plan

- [x] All 135 tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)