### PR TITLE
feat: CNAME chain depth tracking in dangling output

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Once related root domains are identified, enumerate subdomains for each and comb
 | [#87](https://github.com/incendiary/DNSResolver/issues/87) | ✅ v1.10.2 | Version string — printed at startup and in run summary; `--version` flag added |
 | [#89](https://github.com/incendiary/DNSResolver/issues/89) | ✅ v1.10.3 | Self-referential CNAMEs classified as `self_referential` (misconfiguration) not takeover candidates |
 | [#91](https://github.com/incendiary/DNSResolver/issues/91) | ✅ v1.10.4 | README: fix venv path, add `--version` to options table, update architecture diagram, clean roadmap |
+| [#92](https://github.com/incendiary/DNSResolver/issues/92) | ✅ v1.11.0 | CNAME chain depth tracking — dangling output now includes hop count and full chain path (`a -> b -> c`) for faster triage |
 
 ## Contributing
 

--- a/classes/run_summary.py
+++ b/classes/run_summary.py
@@ -41,11 +41,13 @@ class RunSummary:
             parts = line.split("|")
             if len(parts) >= 5:
                 _orig, current, category, recommendation, evidence = parts[:5]
+                depth = int(parts[5]) if len(parts) > 5 else 0
+                chain = parts[6] if len(parts) > 6 else None
                 if category == "unknown":
-                    unclassified.append((_orig, current))
+                    unclassified.append((_orig, current, depth, chain))
                 else:
                     classified.setdefault(category, []).append(
-                        (current, recommendation, evidence)
+                        (current, recommendation, evidence, depth, chain)
                     )
 
         classified_count = sum(len(v) for v in classified.values())
@@ -81,10 +83,12 @@ class RunSummary:
                 print(f"  Classified dangling CNAMEs ({classified_count})")
                 for category, entries in sorted(classified.items()):
                     print(f"    [{category}]")
-                    for current, rec, evidence in entries:
+                    for current, rec, evidence, depth, chain in entries:
                         print(f"      {current}")
                         print(f"        Recommendation : {rec}")
                         print(f"        Evidence       : {evidence}")
+                        if depth > 0 and chain:
+                            print(f"        Chain ({depth} hop{'s' if depth != 1 else ''})  : {chain}")
 
             if ns_takeover:
                 print()
@@ -106,9 +110,13 @@ class RunSummary:
                 print(
                     f"  Unclassified dangling CNAMEs ({unclassified_count}) — investigate manually"
                 )
-                for root_domain, cname_target in unclassified:
+                for root_domain, cname_target, depth, chain in unclassified:
                     print(f"    [?] {root_domain}")
                     print(f"          CNAME target : {cname_target}")
+                    if depth > 0 and chain:
+                        print(
+                            f"          Chain ({depth} hop{'s' if depth != 1 else ''})  : {chain}"
+                        )
                     print(
                         "          Risk         : Target does not resolve — if it can be claimed,"
                     )

--- a/classes/takeover_detector.py
+++ b/classes/takeover_detector.py
@@ -73,7 +73,12 @@ class TakeoverDetector:
             domain_context.add_dangling_domain_to_domains(current_domain)
         return is_dangling or is_nstakeover
 
-    async def check_dangling_cname_async(self, domain_context, current_domain, depth=0):
+    async def check_dangling_cname_async(
+        self, domain_context, current_domain, depth=0, chain=None
+    ):
+        if chain is None:
+            chain = [current_domain]
+
         if depth >= MAX_CNAME_DEPTH:
             self.env_manager.log_info(
                 f"CNAME chain depth limit ({MAX_CNAME_DEPTH}) reached for "
@@ -98,7 +103,7 @@ class TakeoverDetector:
                     target += "."
                 self.env_manager.log_info(f"CNAME target: {target}")
                 if await self.check_dangling_cname_async(
-                    domain_context, target, depth + 1
+                    domain_context, target, depth + 1, chain + [target]
                 ):
                     return True
         except aiodns.error.DNSError as e:
@@ -148,9 +153,10 @@ class TakeoverDetector:
             category, recommendation, evidence_link = (
                 DomainCategoriser.categorise_domain(current_domain, patterns)
             )
+        chain_str = " -> ".join(h.rstrip(".") for h in chain)
         await self.env_manager.write_to_file(
             output_files["standard"]["takeover"],
-            f"DANGLING|{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}",
+            f"DANGLING|{original_domain}|{current_domain}|{category}|{recommendation}|{evidence_link}|{depth}|{chain_str}",
         )
         self.env_manager.log_info(
             f"Domain {current_domain} is a dangling CNAME with category: {category}"

--- a/tests/test_run_summary.py
+++ b/tests/test_run_summary.py
@@ -184,6 +184,51 @@ def test_both_dangling_and_ns_takeover_total_count(tmp_path, capsys):
 
 
 # ---------------------------------------------------------------------------
+# CNAME chain depth tracking
+# ---------------------------------------------------------------------------
+
+
+def test_classified_cname_chain_shown_when_depth_gt_zero(tmp_path, capsys):
+    """A classified dangling CNAME with depth > 0 must show the full hop chain."""
+    dangling = (
+        "DANGLING|sub.victim.com|c.cdn.com|aws_s3|Remove CNAME|https://evidence.link|2"
+        "|sub.victim.com -> b.cdn.com -> c.cdn.com\n"
+    )
+    summary = _make_summary(tmp_path, {"takeover": dangling})
+    summary.display(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "Chain (2 hops)" in out
+    assert "sub.victim.com -> b.cdn.com -> c.cdn.com" in out
+
+
+def test_unclassified_cname_chain_shown_when_depth_gt_zero(tmp_path, capsys):
+    """An unclassified dangling CNAME with depth > 0 must show the full hop chain."""
+    dangling = (
+        "DANGLING|sub.victim.com|mystery.example.com|unknown|Unclassified|N/A|1"
+        "|sub.victim.com -> mystery.example.com\n"
+    )
+    summary = _make_summary(tmp_path, {"takeover": dangling})
+    summary.display(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "Chain (1 hop)" in out
+    assert "sub.victim.com -> mystery.example.com" in out
+
+
+def test_legacy_dangling_line_no_depth_still_parses(tmp_path, capsys):
+    """A DANGLING line without depth/chain fields (pre-v1.11 format) parses without error."""
+    dangling = "DANGLING|root.example.com|app.s3.amazonaws.com|aws_s3|Remove the CNAME|https://evidence.link\n"
+    summary = _make_summary(tmp_path, {"takeover": dangling})
+    summary.display(total_input=1, failed_count=0)
+
+    out = capsys.readouterr().out
+    assert "Classified dangling CNAMEs (1)" in out
+    assert "app.s3.amazonaws.com" in out
+    assert "Chain" not in out  # no chain line for depth=0 / missing fields
+
+
+# ---------------------------------------------------------------------------
 # Resilience
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `TakeoverDetector.check_dangling_cname_async` now threads a `chain` list through recursion, appending each hop as it follows CNAME records
- On detecting a dangling target, two new fields are appended to the `DANGLING` pipe-delimited output line: hop depth (int) and chain path string (`a -> b -> c`)
- `RunSummary.display` parses the new fields and prints the chain under any classified or unclassified entry where depth > 0
- Output from earlier versions parses correctly — new fields are optional (`parts[:5]` logic unchanged)

## Test plan

- [ ] `pytest tests/test_run_summary.py` — 14 tests pass (3 new: chain in classified, chain in unclassified, legacy format backward compat)
- [ ] Verify a multi-hop CNAME chain (e.g. `sub -> cdn-alias -> cdn-origin [NXDOMAIN]`) shows `Chain (2 hops) : sub -> cdn-alias -> cdn-origin` in run summary
- [ ] Verify a direct dangling (no CNAME hops, depth=0) shows no Chain line

🤖 Generated with [Claude Code](https://claude.com/claude-code)